### PR TITLE
Fix the incorrect reported workspace URL

### DIFF
--- a/pkg/solver/singlehost.go
+++ b/pkg/solver/singlehost.go
@@ -145,7 +145,7 @@ func (c *CheRoutingSolver) singlehostExposedEndpoints(manager *dwoche.CheManager
 
 			publicURLPrefix := getPublicURLPrefixForEndpoint(workspaceID, machineName, endpoint)
 
-			publicURL := scheme + "://" + path.Join(host, publicURLPrefix, endpoint.Path)
+			publicURL := scheme + "://" + path.Join(host, publicURLPrefix, endpoint.Path) + "/"
 
 			attrs := map[string]string{}
 			err := endpoint.Attributes.Into(&attrs)

--- a/pkg/solver/singlehost.go
+++ b/pkg/solver/singlehost.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"strings"
 
 	dwoche "github.com/che-incubator/devworkspace-che-operator/apis/che-controller/v1alpha1"
 	"github.com/che-incubator/devworkspace-che-operator/pkg/defaults"
@@ -145,7 +146,12 @@ func (c *CheRoutingSolver) singlehostExposedEndpoints(manager *dwoche.CheManager
 
 			publicURLPrefix := getPublicURLPrefixForEndpoint(workspaceID, machineName, endpoint)
 
-			publicURL := scheme + "://" + path.Join(host, publicURLPrefix, endpoint.Path) + "/"
+			publicURL := scheme + "://" + path.Join(host, publicURLPrefix, endpoint.Path)
+
+			// path.Join() removes the trailing slashes, so make sure to reintroduce that if required.
+			if endpoint.Path == "" || strings.HasSuffix(endpoint.Path, "/") {
+				publicURL = publicURL + "/"
+			}
 
 			attrs := map[string]string{}
 			err := endpoint.Attributes.Into(&attrs)


### PR DESCRIPTION
### What does this PR do?
This fixes the reported workspace URL by making sure it honors the trailing slash of the endpoint path.

