### PR TITLE
Use the latest version of devworkspace-operator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/devfile/api v0.0.0-20201125082321-aeda60d43619
-	github.com/devfile/devworkspace-operator v0.0.0-20210125082355-28b4522cab2c
+	github.com/devfile/devworkspace-operator v0.0.0-20210208163832-3bdccac9f3aa
 	github.com/google/go-cmp v0.5.0
 	github.com/openshift/api v0.0.0-20200205133042-34f0ec8dab87
 	k8s.io/api v0.18.8
@@ -13,5 +13,3 @@ require (
 	sigs.k8s.io/controller-runtime v0.6.3
 	sigs.k8s.io/yaml v1.2.0
 )
-
-replace github.com/devfile/devworkspace-operator => github.com/metlos/devworkspace-operator v0.0.0-20210203210500-d41bfe6bcb51

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/devfile/api v0.0.0-20201125082321-aeda60d43619 h1:1pTtDONDby55+kqHhvSqPiVKIGf1OJRY1vXCeHFG+wU=
 github.com/devfile/api v0.0.0-20201125082321-aeda60d43619/go.mod h1:/aDiwWjDEW/fY1/Ig8umVtmneAXKZImnLvWqzMlcfrY=
+github.com/devfile/devworkspace-operator v0.0.0-20210208163832-3bdccac9f3aa h1:gpDUY8N5OGqan/Uul1I6moosXUtm6ChjBQzNzJ2gZfM=
+github.com/devfile/devworkspace-operator v0.0.0-20210208163832-3bdccac9f3aa/go.mod h1:ayJ/0OfkuuafeCgdhcMOGSgZfePUVECmwTCWSzdBgRM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/docker/docker v0.7.3-0.20190327010347-be7ac8be2ae0/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
@@ -58,9 +60,6 @@ github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZ
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/eclipse/che-go-jsonrpc v0.0.0-20200317130110-931966b891fe/go.mod h1:6xlEQ1tM4Ago8A2jPjTrHy60Oy7Kv28DcefZPZMlwWE=
-github.com/eclipse/che-plugin-broker v3.4.0+incompatible h1:5jV67XReIZqkTTMzaEMblgIta5AJST4xmU5lXAvHEh4=
-github.com/eclipse/che-plugin-broker v3.4.0+incompatible/go.mod h1:V5mZYiAFCw8aQ3VCCs6a4FwO7qeVOLixY2baT6bMJI8=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
@@ -230,8 +229,6 @@ github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNx
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/metlos/devworkspace-operator v0.0.0-20210203210500-d41bfe6bcb51 h1:hPtAW40vQLJD0FMAal78ozXHXPFl2pwW9fQ0+t35QSs=
-github.com/metlos/devworkspace-operator v0.0.0-20210203210500-d41bfe6bcb51/go.mod h1:5HB56/czS3Mi7n7q/9BIliWFqd8EFyAtAaYWNCuPXG8=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/reflectwalk v1.0.1/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->
### What does this PR do?
This just updates to the latest version of the devworkspace-operator so that we don't depend on a fork.

