### PR TITLE
Remove linux/s390x from the list of platforms we build the image for.

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -36,7 +36,8 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         file: ./build/dockerfiles/Dockerfile
-        platforms: linux/amd64,linux/ppc64le,linux/s390x
+        # go compiler segfaults on linux/s390x so leaving that out for now
+        platforms: linux/amd64,linux/ppc64le
         push: true
         tags: quay.io/che-incubator/devworkspace-che-operator:latest
     -

--- a/deploy/generate-deployment.sh
+++ b/deploy/generate-deployment.sh
@@ -121,7 +121,7 @@ echo "Using yq $(yq --version | head -1 | cut -d' ' -f2)"
 
 # check that we're using compatible versions of the tools
 KUSTOMIZE_VERSION=$(kustomize version | cut -d: -f2 | cut -d' ' -f1 | awk -F '/v' '{print $2}')
-EXPECTED_KUSTOMIZE_VERSION="3.9.3"
+EXPECTED_KUSTOMIZE_VERSION="4.0.1"
 if [[ $KUSTOMIZE_VERSION != $EXPECTED_KUSTOMIZE_VERSION ]]; then
     echo "The last known version of kustomize in Github actions is $EXPECTED_KUSTOMIZE_VERSION but we're using $KUSTOMIZE_VERSION."
     echo


### PR DESCRIPTION
### What does this PR do?
The go compiler segfaults for reasons that we were not able to identify yet. Therefore remove the architecture from the list of platforms that we build our dockerimage for.
