### PR TITLE
Prevent deletion of the che manager if there still are some workspaces routed through it.

### DIFF
--- a/apis/che-controller/v1alpha1/component_types.go
+++ b/apis/che-controller/v1alpha1/component_types.go
@@ -55,10 +55,27 @@ const (
 	GatewayPhaseInactive     = "Inactive"
 )
 
+type ManagerPhase string
+
+const (
+	ManagerPhaseActive          = "Active"
+	ManagerPhasePendingDeletion = "PendingDeletion"
+)
+
 // +k8s:openapi-gen=true
 type CheManagerStatus struct {
+	// GatewayPhase specifies the phase in which the singlehost gateway deployment currently is.
+	// If the manager routing is not singlehost, this is "Inactive"
 	GatewayPhase GatewayPhase `json:"gatewayPhase,omitempty"`
-	GatewayHost  string       `json:"gatewayHost,omitempty"`
+
+	// GatewayHost is the resolved host of the ingress/route, on which the gateway is accessible.
+	GatewayHost string `json:"gatewayHost,omitempty"`
+
+	// Phase is the phase in which the manager as a whole finds itself in.
+	Phase ManagerPhase `json:"phase,omitempty"`
+
+	// Message contains further human-readable info for why the manager is in the phase it currently is.
+	Message string `json:"omitempty"`
 }
 
 // CheManager is the configuration of the CheManager layer of Devworkspace.

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -49,9 +49,19 @@ spec:
           status:
             properties:
               gatewayHost:
+                description: GatewayHost is the resolved host of the ingress/route, on which the gateway is accessible.
                 type: string
               gatewayPhase:
+                description: GatewayPhase specifies the phase in which the singlehost gateway deployment currently is. If the manager routing is not singlehost, this is "Inactive"
                 type: string
+              omitempty:
+                description: Message contains further human-readable info for why the manager is in the phase it currently is.
+                type: string
+              phase:
+                description: Phase is the phase in which the manager as a whole finds itself in.
+                type: string
+            required:
+            - omitempty
             type: object
         type: object
     served: true
@@ -231,6 +241,12 @@ rules:
   verbs:
   - get
   - patch
+  - update
+- apiGroups:
+  - che.eclipse.org
+  resources:
+  - chemanagers/finalizers
+  verbs:
   - update
 - apiGroups:
   - controller.devfile.io

--- a/deploy/deployment/kubernetes/objects/chemanagers.che.eclipse.org.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/chemanagers.che.eclipse.org.CustomResourceDefinition.yaml
@@ -49,9 +49,19 @@ spec:
           status:
             properties:
               gatewayHost:
+                description: GatewayHost is the resolved host of the ingress/route, on which the gateway is accessible.
                 type: string
               gatewayPhase:
+                description: GatewayPhase specifies the phase in which the singlehost gateway deployment currently is. If the manager routing is not singlehost, this is "Inactive"
                 type: string
+              omitempty:
+                description: Message contains further human-readable info for why the manager is in the phase it currently is.
+                type: string
+              phase:
+                description: Phase is the phase in which the manager as a whole finds itself in.
+                type: string
+            required:
+            - omitempty
             type: object
         type: object
     served: true

--- a/deploy/deployment/kubernetes/objects/devworkspace-che-role.ClusterRole.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspace-che-role.ClusterRole.yaml
@@ -100,6 +100,12 @@ rules:
   - patch
   - update
 - apiGroups:
+  - che.eclipse.org
+  resources:
+  - chemanagers/finalizers
+  verbs:
+  - update
+- apiGroups:
   - controller.devfile.io
   resources:
   - workspaceroutings

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -49,9 +49,19 @@ spec:
           status:
             properties:
               gatewayHost:
+                description: GatewayHost is the resolved host of the ingress/route, on which the gateway is accessible.
                 type: string
               gatewayPhase:
+                description: GatewayPhase specifies the phase in which the singlehost gateway deployment currently is. If the manager routing is not singlehost, this is "Inactive"
                 type: string
+              omitempty:
+                description: Message contains further human-readable info for why the manager is in the phase it currently is.
+                type: string
+              phase:
+                description: Phase is the phase in which the manager as a whole finds itself in.
+                type: string
+            required:
+            - omitempty
             type: object
         type: object
     served: true
@@ -231,6 +241,12 @@ rules:
   verbs:
   - get
   - patch
+  - update
+- apiGroups:
+  - che.eclipse.org
+  resources:
+  - chemanagers/finalizers
+  verbs:
   - update
 - apiGroups:
   - controller.devfile.io

--- a/deploy/deployment/openshift/objects/chemanagers.che.eclipse.org.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/chemanagers.che.eclipse.org.CustomResourceDefinition.yaml
@@ -49,9 +49,19 @@ spec:
           status:
             properties:
               gatewayHost:
+                description: GatewayHost is the resolved host of the ingress/route, on which the gateway is accessible.
                 type: string
               gatewayPhase:
+                description: GatewayPhase specifies the phase in which the singlehost gateway deployment currently is. If the manager routing is not singlehost, this is "Inactive"
                 type: string
+              omitempty:
+                description: Message contains further human-readable info for why the manager is in the phase it currently is.
+                type: string
+              phase:
+                description: Phase is the phase in which the manager as a whole finds itself in.
+                type: string
+            required:
+            - omitempty
             type: object
         type: object
     served: true

--- a/deploy/deployment/openshift/objects/devworkspace-che-role.ClusterRole.yaml
+++ b/deploy/deployment/openshift/objects/devworkspace-che-role.ClusterRole.yaml
@@ -100,6 +100,12 @@ rules:
   - patch
   - update
 - apiGroups:
+  - che.eclipse.org
+  resources:
+  - chemanagers/finalizers
+  verbs:
+  - update
+- apiGroups:
   - controller.devfile.io
   resources:
   - workspaceroutings

--- a/deploy/templates/components/rbac/role.yaml
+++ b/deploy/templates/components/rbac/role.yaml
@@ -113,6 +113,12 @@ rules:
   - patch
   - update
 - apiGroups:
+  - che.eclipse.org
+  resources:
+  - chemanagers/finalizers
+  verbs:
+  - update
+- apiGroups:
   - controller.devfile.io
   resources:
   - workspaceroutings

--- a/deploy/templates/crd/bases/che.eclipse.org_chemanagers.yaml
+++ b/deploy/templates/crd/bases/che.eclipse.org_chemanagers.yaml
@@ -65,9 +65,24 @@ spec:
           status:
             properties:
               gatewayHost:
+                description: GatewayHost is the resolved host of the ingress/route,
+                  on which the gateway is accessible.
                 type: string
               gatewayPhase:
+                description: GatewayPhase specifies the phase in which the singlehost
+                  gateway deployment currently is. If the manager routing is not singlehost,
+                  this is "Inactive"
                 type: string
+              omitempty:
+                description: Message contains further human-readable info for why
+                  the manager is in the phase it currently is.
+                type: string
+              phase:
+                description: Phase is the phase in which the manager as a whole finds
+                  itself in.
+                type: string
+            required:
+            - omitempty
             type: object
         type: object
     served: true

--- a/pkg/manager/chemanager_controller.go
+++ b/pkg/manager/chemanager_controller.go
@@ -14,6 +14,7 @@ package manager
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/che-incubator/devworkspace-che-operator/apis/che-controller/v1alpha1"
@@ -35,6 +36,10 @@ var (
 	log             = ctrl.Log.WithName("che")
 	currentManagers = map[client.ObjectKey]v1alpha1.CheManager{}
 	managerAccess   = sync.Mutex{}
+)
+
+const (
+	finalizerName = "chemanager.che.eclipse.org"
 )
 
 type CheReconciler struct {
@@ -128,7 +133,17 @@ func (r *CheReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	}
 
 	if current.GetDeletionTimestamp() != nil {
-		return ctrl.Result{}, r.finalize(current)
+		return ctrl.Result{}, r.finalize(ctx, current)
+	}
+
+	finalizerUpdated, err := r.ensureFinalizer(ctx, current)
+	if err != nil {
+		log.Info("Failed to set a finalizer on %s", req.String())
+		return ctrl.Result{}, err
+	} else if finalizerUpdated {
+		// we've updated the object with a new finalizer, so we will enter another reconciliation loop shortly
+		// we don't add the manager into the shared map just yet, because we have actually not reconciled it fully.
+		return ctrl.Result{}, nil
 	}
 
 	var changed bool
@@ -164,6 +179,10 @@ func (r *CheReconciler) updateStatus(ctx context.Context, manager *v1alpha1.CheM
 
 	manager.Status.GatewayHost = host
 
+	// set this unconditionally, because the only other value is set using the finalizer
+	manager.Status.Phase = v1alpha1.ManagerPhaseActive
+	manager.Status.Message = ""
+
 	if currentPhase != manager.Status.GatewayPhase || currentHost != manager.Status.GatewayHost {
 		return ctrl.Result{Requeue: true}, r.client.Status().Update(ctx, manager)
 	}
@@ -171,9 +190,31 @@ func (r *CheReconciler) updateStatus(ctx context.Context, manager *v1alpha1.CheM
 	return ctrl.Result{Requeue: currentPhase == v1alpha1.GatewayPhaseInitializing}, nil
 }
 
-func (r *CheReconciler) finalize(router *v1alpha1.CheManager) error {
-	// implement if needed
-	return nil
+func (r *CheReconciler) finalize(ctx context.Context, manager *v1alpha1.CheManager) (err error) {
+	if manager.Spec.Routing == v1alpha1.SingleHost {
+		err = r.singlehostFinalize(ctx, manager)
+	} else {
+		err = r.multihostFinalize(ctx, manager)
+	}
+
+	if err == nil {
+		finalizers := []string{}
+		for i := range manager.Finalizers {
+			if manager.Finalizers[i] != finalizerName {
+				finalizers = append(finalizers, manager.Finalizers[i])
+			}
+		}
+
+		manager.Finalizers = finalizers
+
+		err = r.client.Update(ctx, manager)
+	} else {
+		manager.Status.Phase = v1alpha1.ManagerPhasePendingDeletion
+		manager.Status.Message = fmt.Sprintf("Finalization has failed: %s", err.Error())
+		err = r.client.Status().Update(ctx, manager)
+	}
+
+	return err
 }
 
 func (r *CheReconciler) reconcileGateway(ctx context.Context, manager *v1alpha1.CheManager) (bool, string, error) {
@@ -188,4 +229,24 @@ func (r *CheReconciler) reconcileGateway(ctx context.Context, manager *v1alpha1.
 	}
 
 	return changed, host, err
+}
+
+func (r *CheReconciler) ensureFinalizer(ctx context.Context, manager *v1alpha1.CheManager) (updated bool, err error) {
+
+	needsUpdate := true
+	if manager.Finalizers != nil {
+		for i := range manager.Finalizers {
+			if manager.Finalizers[i] == finalizerName {
+				needsUpdate = false
+				break
+			}
+		}
+	}
+
+	if needsUpdate {
+		manager.Finalizers = append(manager.Finalizers, finalizerName)
+		err = r.client.Update(ctx, manager)
+	}
+
+	return needsUpdate, err
 }

--- a/pkg/manager/chemanager_controller.go
+++ b/pkg/manager/chemanager_controller.go
@@ -39,7 +39,8 @@ var (
 )
 
 const (
-	finalizerName = "chemanager.che.eclipse.org"
+	// FinalizerName is the name of the finalizer put on the Che Manager resources by the controller. Public for testing purposes.
+	FinalizerName = "chemanager.che.eclipse.org"
 )
 
 type CheReconciler struct {
@@ -200,7 +201,7 @@ func (r *CheReconciler) finalize(ctx context.Context, manager *v1alpha1.CheManag
 	if err == nil {
 		finalizers := []string{}
 		for i := range manager.Finalizers {
-			if manager.Finalizers[i] != finalizerName {
+			if manager.Finalizers[i] != FinalizerName {
 				finalizers = append(finalizers, manager.Finalizers[i])
 			}
 		}
@@ -236,7 +237,7 @@ func (r *CheReconciler) ensureFinalizer(ctx context.Context, manager *v1alpha1.C
 	needsUpdate := true
 	if manager.Finalizers != nil {
 		for i := range manager.Finalizers {
-			if manager.Finalizers[i] == finalizerName {
+			if manager.Finalizers[i] == FinalizerName {
 				needsUpdate = false
 				break
 			}
@@ -244,7 +245,7 @@ func (r *CheReconciler) ensureFinalizer(ctx context.Context, manager *v1alpha1.C
 	}
 
 	if needsUpdate {
-		manager.Finalizers = append(manager.Finalizers, finalizerName)
+		manager.Finalizers = append(manager.Finalizers, FinalizerName)
 		err = r.client.Update(ctx, manager)
 	}
 

--- a/pkg/manager/multihost.go
+++ b/pkg/manager/multihost.go
@@ -1,0 +1,13 @@
+package manager
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/che-incubator/devworkspace-che-operator/apis/che-controller/v1alpha1"
+)
+
+func (r *CheReconciler) multihostFinalize(ctx context.Context, manager *v1alpha1.CheManager) error {
+	// Multihost not supported at the moment
+	return fmt.Errorf("Multihost mode not supported at the moment.")
+}

--- a/pkg/manager/singlehost.go
+++ b/pkg/manager/singlehost.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/che-incubator/devworkspace-che-operator/apis/che-controller/v1alpha1"
@@ -16,7 +17,10 @@ func (r *CheReconciler) singlehostFinalize(ctx context.Context, manager *v1alpha
 	// we detect that by the presence of the gateway configmaps in the namespace of the manager
 	list := corev1.ConfigMapList{}
 
-	err := r.client.List(ctx, &list, &client.ListOptions{Namespace: manager.Namespace})
+	err := r.client.List(ctx, &list, &client.ListOptions{
+		Namespace:     manager.Namespace,
+		LabelSelector: labels.SelectorFromSet(defaults.GetLabelsForComponent(manager, "gateway-config")),
+	})
 	if err != nil {
 		return err
 	}

--- a/pkg/manager/singlehost.go
+++ b/pkg/manager/singlehost.go
@@ -1,0 +1,37 @@
+package manager
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/che-incubator/devworkspace-che-operator/apis/che-controller/v1alpha1"
+	"github.com/che-incubator/devworkspace-che-operator/pkg/defaults"
+)
+
+func (r *CheReconciler) singlehostFinalize(ctx context.Context, manager *v1alpha1.CheManager) error {
+	// we need to stop the reconcile if there are workspaces handled by it.
+	// we detect that by the presence of the gateway configmaps in the namespace of the manager
+	list := corev1.ConfigMapList{}
+
+	err := r.client.List(ctx, &list, &client.ListOptions{Namespace: manager.Namespace})
+	if err != nil {
+		return err
+	}
+
+	workspaceCount := 0
+
+	for _, c := range list.Items {
+		if c.Annotations[defaults.ConfigAnnotationCheManagerName] == manager.Name && c.Annotations[defaults.ConfigAnnotationCheManagerNamespace] == manager.Namespace {
+			workspaceCount++
+		}
+	}
+
+	if workspaceCount > 0 {
+		return fmt.Errorf("there are %d workspaces associated with this Che manager", workspaceCount)
+	}
+
+	return nil
+}

--- a/pkg/solver/singlehost_test.go
+++ b/pkg/solver/singlehost_test.go
@@ -42,8 +42,9 @@ func getSpecObjects(t *testing.T, routing *dwo.WorkspaceRouting) (client.Client,
 	scheme := createTestScheme()
 	cheManager := &v1alpha1.CheManager{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "che",
-			Namespace: "ns",
+			Name:       "che",
+			Namespace:  "ns",
+			Finalizers: []string{manager.FinalizerName},
 		},
 		Spec: v1alpha1.CheManagerSpec{
 			Host:    "over.the.rainbow",


### PR DESCRIPTION
### What does this PR do?
This add finalization logic to the che manager objects, checking there are still some running workspaces routed through the manager.

### What issues does this PR fix or reference?
eclipse/che#19067