### PR TITLE
Fix panic on openshift

### DIFF
--- a/pkg/gateway/route.go
+++ b/pkg/gateway/route.go
@@ -92,8 +92,10 @@ func (g *CheGateway) reconcileRoute(syncer sync.Syncer, ctx context.Context, man
 		var inCluster runtime.Object
 
 		changed, inCluster, err = syncer.Sync(ctx, manager, route, diffOpts)
+		if err != nil {
+			return changed, "", err
+		}
 		routeHost = inCluster.(*routev1.Route).Spec.Host
-
 	}
 
 	return changed, routeHost, err

--- a/samples/che-manager-openshift.yaml
+++ b/samples/che-manager-openshift.yaml
@@ -1,0 +1,7 @@
+kind: CheManager
+apiVersion: che.eclipse.org/v1alpha1
+metadata:
+  name: che
+spec:
+  routing: singlehost
+


### PR DESCRIPTION
### What does this PR do?
Fixes a panic due to missing error handling when creating routes. These seem to be intermittent and the operator is able to reconcile the the gateway eventually.