### PR TITLE
Also build images with commit hash as tag, the same way as devworkspa…

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -40,6 +40,7 @@ jobs:
         platforms: linux/amd64,linux/ppc64le
         push: true
         tags: quay.io/che-incubator/devworkspace-che-operator:latest
+        tag_with_sha: true
     -
       name: Clear
       run: |


### PR DESCRIPTION
### What does this PR do?
This adds an additional tag to the currently built docker image containing the commit hash. This is what devworkspace-operator is doing, too, and is good for identifying the concrete commit a certain image comes from.
