### PR TITLE
Endpoints on http protocol are served over https when exposed through gateway

### DIFF
--- a/pkg/solver/che_routing.go
+++ b/pkg/solver/che_routing.go
@@ -143,11 +143,6 @@ func (c *CheRoutingSolver) cheExposedEndpoints(manager *dwoche.CheManager, works
 				continue
 			}
 
-			if endpoint.Secure {
-				// TODO this should also do the magic of ensuring user authentication however we are going to do it
-				// in the future
-			}
-
 			// try to find the endpoint in the ingresses/routes first. If it is there, it is exposed on a subdomain
 			// otherwise it is exposed through the gateway
 			var endpointURL string

--- a/pkg/solver/che_routing.go
+++ b/pkg/solver/che_routing.go
@@ -50,6 +50,14 @@ var (
 	configMapDiffOpts = cmpopts.IgnoreFields(corev1.ConfigMap{}, "TypeMeta", "ObjectMeta")
 )
 
+// keys are port numbers, values are maps where keys are endpoint names (in case we need more than 1 endpoint for a single port) and values
+// contain info about the intended endpoint scheme and the order in which the port is defined (used for unique naming)
+type portMapping map[int32]map[string]portMappingValue
+type portMappingValue struct {
+	endpointScheme string
+	order          int
+}
+
 func (c *CheRoutingSolver) cheSpecObjects(cheManager *dwoche.CheManager, routing *dwo.DevWorkspaceRouting, workspaceMeta solvers.WorkspaceMetadata) (solvers.RoutingObjects, error) {
 	objs := solvers.RoutingObjects{}
 
@@ -128,12 +136,7 @@ func (c *CheRoutingSolver) cheExposedEndpoints(manager *dwoche.CheManager, works
 				continue
 			}
 
-			var scheme string
-			if endpoint.Protocol == "" {
-				scheme = "http"
-			} else {
-				scheme = string(endpoint.Protocol)
-			}
+			scheme := determineEndpointScheme(!manager.Spec.GatewayDisabled, endpoint)
 
 			if !isExposableScheme(scheme) {
 				// we cannot expose non-http endpoints publicly, because ingresses/routes only support http(s)
@@ -141,8 +144,6 @@ func (c *CheRoutingSolver) cheExposedEndpoints(manager *dwoche.CheManager, works
 			}
 
 			if endpoint.Secure {
-				scheme = secureScheme(scheme)
-
 				// TODO this should also do the magic of ensuring user authentication however we are going to do it
 				// in the future
 			}
@@ -207,6 +208,10 @@ func secureScheme(scheme string) string {
 	} else {
 		return scheme
 	}
+}
+
+func isSecureScheme(scheme string) bool {
+	return scheme == "https" || scheme == "wss"
 }
 
 func (c *CheRoutingSolver) getGatewayConfigsAndFillRoutingObjects(cheManager *dwoche.CheManager, workspaceID string, routing *dwo.DevWorkspaceRouting, objs *solvers.RoutingObjects) ([]corev1.ConfigMap, error) {
@@ -280,9 +285,9 @@ func getTrackedEndpointName(endpoint *dw.Endpoint) string {
 // we need to support unique endpoints - so 1 port can actually be accessible
 // multiple times, each time using a different resulting external URL.
 // non-unique endpoints are all represented using a single external URL
-func classifyEndpoints(gatewayEnabled bool, order *int, endpoints *dwo.EndpointList) (singlehostPorts map[int32]map[string]int, multihostPorts map[int32]map[string]int) {
-	singlehostPorts = map[int32]map[string]int{}
-	multihostPorts = map[int32]map[string]int{}
+func classifyEndpoints(gatewayEnabled bool, order *int, endpoints *dwo.EndpointList) (singlehostPorts portMapping, multihostPorts portMapping) {
+	singlehostPorts = portMapping{}
+	multihostPorts = portMapping{}
 	for _, e := range *endpoints {
 		if e.Exposure != dw.PublicEndpointExposure {
 			continue
@@ -301,11 +306,14 @@ func classifyEndpoints(gatewayEnabled bool, order *int, endpoints *dwo.EndpointL
 		}
 
 		if ports[i] == nil {
-			ports[i] = map[string]int{}
+			ports[i] = map[string]portMappingValue{}
 		}
 
 		if _, ok := ports[i][name]; !ok {
-			ports[i][name] = *order
+			ports[i][name] = portMappingValue{
+				order:          *order,
+				endpointScheme: determineEndpointScheme(gatewayEnabled, e),
+			}
 			*order = *order + 1
 		}
 	}
@@ -313,7 +321,7 @@ func classifyEndpoints(gatewayEnabled bool, order *int, endpoints *dwo.EndpointL
 	return
 }
 
-func addToTraefikConfig(namespace string, workspaceID string, machineName string, portMapping map[int32]map[string]int, cfg *traefikConfig) {
+func addToTraefikConfig(namespace string, workspaceID string, machineName string, portMapping portMapping, cfg *traefikConfig) {
 	rtrs := cfg.HTTP.Routers
 	srvcs := cfg.HTTP.Services
 	mdls := cfg.HTTP.Middlewares
@@ -353,17 +361,17 @@ func addToTraefikConfig(namespace string, workspaceID string, machineName string
 	}
 }
 
-func addToRoutingObjects(cheManager *v1alpha1.CheManager, namespace string, baseDomain string, workspaceID string, machineName string, portMapping map[int32]map[string]int, objs *solvers.RoutingObjects) {
+func addToRoutingObjects(cheManager *v1alpha1.CheManager, namespace string, baseDomain string, workspaceID string, machineName string, portMapping portMapping, objs *solvers.RoutingObjects) {
 	isOpenShift := infrastructure.IsOpenShift()
 
 	for port, names := range portMapping {
 		backingService := findServiceForPort(port, objs)
-		for endpointName, order := range names {
+		for endpointName, val := range names {
 			if isOpenShift {
-				route := getRouteForService(order, machineName, endpointName, port, baseDomain, workspaceID, backingService)
+				route := getRouteForService(val.order, machineName, endpointName, port, val.endpointScheme, baseDomain, workspaceID, backingService)
 				objs.Routes = append(objs.Routes, route)
 			} else {
-				ingress := getIngressForService(order, machineName, endpointName, port, baseDomain, workspaceID, backingService)
+				ingress := getIngressForService(val.order, machineName, endpointName, port, val.endpointScheme, baseDomain, workspaceID, backingService)
 				objs.Ingresses = append(objs.Ingresses, ingress)
 			}
 		}
@@ -471,4 +479,26 @@ func getPublicURLPrefix(workspaceID string, machineName string, port int32, uniq
 		return fmt.Sprintf(endpointURLPrefixPattern, workspaceID, machineName, port)
 	}
 	return fmt.Sprintf(uniqueEndpointURLPrefixPattern, workspaceID, machineName, uniqueEndpointName)
+}
+
+func determineEndpointScheme(gatewayEnabled bool, e dw.Endpoint) string {
+	var scheme string
+	if e.Protocol == "" {
+		scheme = "http"
+	} else {
+		scheme = string(e.Protocol)
+	}
+
+	upgradeToSecure := e.Secure
+
+	// gateway is always on HTTPS, so if the endpoint is served through the gateway, we need to use the TLS'd variant.
+	if gatewayEnabled && e.Attributes.GetString(urlRewriteSupportedEndpointAttributeName, nil) == "true" {
+		upgradeToSecure = true
+	}
+
+	if upgradeToSecure {
+		scheme = secureScheme(scheme)
+	}
+
+	return scheme
 }

--- a/pkg/solver/che_routing_test.go
+++ b/pkg/solver/che_routing_test.go
@@ -372,7 +372,7 @@ func TestReportRelocatableExposedEndpoints(t *testing.T) {
 	if e3.Name != "e3" {
 		t.Errorf("The third endpoint should have been e3 but is %s", e1.Name)
 	}
-	if e3.Url != "http://over.the.rainbow/wsid/m1/9999/" {
+	if e3.Url != "https://over.the.rainbow/wsid/m1/9999/" {
 		t.Errorf("The e3 endpoint should have the following URL: '%s' but has '%s'.", "https://over.the.rainbow/wsid/m1/9999/", e3.Url)
 	}
 }


### PR DESCRIPTION
### What does this PR do?
Endpoints on http protocol are served over https when exposed through
gateway.

Gateway is always exposed over HTTPS. If the endpoint declared an http protocol, the clients of devworkspace would try to access it on the http url and would be redirected to the https url. This causes confusion and breakage so we should take care to report the correct URLs right off the bat.

Note that the correct TLS implementation on Kubernetes requires us to serve the certificates, too, (I think), which is not implemented yet and is covered by eclipse/che#19394.

### What issues does this PR fix or reference?
eclipse/che#19393