### PR TITLE
Only detect the k8s platform we're running on in targets that need it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,12 +27,6 @@ else
 K8S_CLI := kubectl
 endif
 
-ifeq ($(shell $(K8S_CLI) api-resources --api-group='route.openshift.io'  2>&1 | grep -o routes),routes)
-PLATFORM := openshift
-else
-PLATFORM := kubernetes
-endif
-
 # our targets don't generate files in a way make assumes
 .PHONY: all clean test compile prepare run run_as_current_user debug deploy undeploy generate_deployment manifests fmt vet generate docker-build docker-push controller-gen help
 
@@ -51,16 +45,16 @@ compile: generate fmt vet
 	go build -o bin/manager main.go
 
 ### prepare: Prepares the cluster for running the operator - deploys CRDs, rbac and the service account
-prepare: _mk_temp manifests
-# hiding the definition the variable in an eval makes it only defined in this target. Otherwise it would
-# be evaluated eagerly at the make start regardless of the target run, resulting in a temporary directory
-# being created needlessly.
-	$(eval PREPAPRE_OUTPUT_DIR := $(shell mktemp -p $(TEMP_DIR) -d))
-	OUTPUT_DIR=$(PREPAPRE_OUTPUT_DIR) DWCO_GENERATED_OVERLAY=support deploy/generate-deployment.sh --split-yaml
+prepare: _mk_temp _platform manifests
+# hiding the definition the variable in an eval makes it only defined once this target has run. 
+# Otherwise it would be evaluated eagerly at the make start regardless of the target run, resulting 
+# in a temporary directory being created needlessly.
+	$(eval PREPARE_OUTPUT_DIR := $(shell mktemp -p $(TEMP_DIR) -d))
+	OUTPUT_DIR=$(PREPARE_OUTPUT_DIR) DWCO_GENERATED_OVERLAY=support deploy/generate-deployment.sh --split-yaml
 # We want to tolerate if the namespace already exists, so || true to ensure the success exit code
 	$(K8S_CLI) create namespace $(DWCO_NAMESPACE) || true
-	$(K8S_CLI) apply -f $(PREPAPRE_OUTPUT_DIR)/$(PLATFORM)/combined.yaml
-	rm -Rf $(PREPAPRE_OUTPUT_DIR)
+	$(K8S_CLI) apply -f $(PREPARE_OUTPUT_DIR)/$(PLATFORM)/combined.yaml
+	rm -Rf $(PREPARE_OUTPUT_DIR)
 
 ### run: Run against the configured Kubernetes cluster in ~/.kube/config using the deployed service account
 run: generate fmt vet prepare
@@ -76,12 +70,12 @@ debug: generate fmt vet prepare
 	dlv debug --listen=:2345 --headless=true --api-version=2 ./main.go --
 	
 ### install: Deploy controller in the configured Kubernetes cluster in ~/.kube/config
-install: generate_deployment
+install: _platform generate_deployment
 	$(K8S_CLI) create namespace $(DWCO_NAMESPACE) || true
 	$(K8S_CLI) apply -f deploy/deployment/$(PLATFORM)/combined.yaml
 
 ### uninstall: Removes everything related to Devworkspace Che from the cluster.
-uninstall: generate_deployment
+uninstall: _platform generate_deployment
 	$(K8S_CLI) delete devworkspaces.workspace.devfile.io --all-namespaces --all --wait || true
 	$(K8S_CLI) delete devworkspacetemplates.workspace.devfile.io --all-namespaces --all || true
 	$(K8S_CLI) delete workspaceroutings.controller.devfile.io --all-namespaces --all --wait || true
@@ -147,3 +141,7 @@ help: Makefile
 _mk_temp:
 	@mkdir -p $(TEMP_DIR)
 
+# detects the kubernetes platform we're currently logged in to.
+_platform:
+	$(eval PLATFORM := $(shell deploy/detect-platform.sh $(K8S_CLI)))
+	@echo Detected Kubernetes platform: $(PLATFORM)

--- a/deploy/detect-platform.sh
+++ b/deploy/detect-platform.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+K8S_CLI=$1
+
+ROUTES_PRESENT=$(${K8S_CLI} api-resources --api-group='route.openshift.io'  2>&1 | grep -o routes)
+if [ "${ROUTES_PRESENT}" == "routes" ]; then \
+    echo openshift
+else
+    echo kubernetes
+fi
+

--- a/deploy/detect-platform.sh
+++ b/deploy/detect-platform.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+# This is a support script for the Makefile to detect the Kubernetes plaform the caller is currently logged into.
+
 K8S_CLI=$1
 
 ROUTES_PRESENT=$(${K8S_CLI} api-resources --api-group='route.openshift.io'  2>&1 | grep -o routes)


### PR DESCRIPTION
### What does this PR do?
Only detect the k8s platform we're running on in targets that need it.

This can be quite slow and does not have to be done during tests at all
for example.
