### PR TITLE
Fix node-js-theia command id

### DIFF
--- a/samples/flattened_theia-nodejs.yaml
+++ b/samples/flattened_theia-nodejs.yaml
@@ -1,7 +1,7 @@
 kind: DevWorkspace
 apiVersion: workspace.devfile.io/v1alpha2
 metadata:
-  name: theia-nodejs
+  name: theia-next
 spec:
   started: true
   routingClass: che

--- a/samples/flattened_theia-nodejs.yaml
+++ b/samples/flattened_theia-nodejs.yaml
@@ -11,20 +11,15 @@ spec:
         git:
           remotes:
             origin: "https://github.com/che-samples/web-nodejs-sample.git"
-
     components:
-
+    ### BEGIN Contributions from Theia plugin ###
+      - name: plugins
+        volume: {}
       - name: theia-ide
         attributes:
           "app.kubernetes.io/name": che-theia.eclipse.org
           "app.kubernetes.io/part-of": che.eclipse.org
           "app.kubernetes.io/component": editor
-
-          # Added by Che-theia at start when detecting, after cloning, that the extensions.json in the repo
-          # contains the vscode-pull-request-github vscode plugin.
-          "che-theia.eclipse.org/vscode-extensions":
-            - https://github.com/microsoft/vscode-pull-request-github/releases/download/v0.8.0/vscode-pull-request-github-0.8.0.vsix
-
         container:
           image: "quay.io/eclipse/che-theia:next"
           env:
@@ -49,7 +44,6 @@ spec:
               protocol: http
               attributes:
                 type: ide
-                cookiesAuthEnabled: "true"
             - name: "webviews"
               exposure: public
               targetPort: 3100
@@ -57,7 +51,6 @@ spec:
               secure: true
               attributes:
                 type: webview
-                cookiesAuthEnabled: "true"
                 unique: "true"
             - name: "theia-dev"
               exposure: public
@@ -77,195 +70,31 @@ spec:
               exposure: public
               targetPort: 13133
               protocol: http
-
-      - name: plugins
-        volume: {}
-
-      - name: vsx-installer  # Mainly reads the container objects and searches for those
-                            # with che-theia.eclipse.org/vscode-extensions attributes to get VSX urls
-                            # Those found in the dedicated containers components are with a sidecar,
-                            # Those found in the che-theia container are without a sidecar.
+      - name: che-theia-terminal
         attributes:
-          "app.kubernetes.io/part-of": che-theia.eclipse.org
-          "app.kubernetes.io/component": bootstrapper
-        container:
-          args:
-            - /bin/sh
-            - '-c'
-            - |
-              KUBE_API_ENDPOINT="https://kubernetes.default.svc/apis/workspace.devfile.io/v1alpha2/namespaces/${CHE_WORKSPACE_NAMESPACE}/devworkspaces/${CHE_WORKSPACE_NAME}" &&\
-              TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token) &&\
-              WORKSPACE=$(curl -fsS --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt -H "Authorization: Bearer ${TOKEN}" $KUBE_API_ENDPOINT) &&\
-              for container in $(echo $WORKSPACE | sed -e 's;[[,]\({"attributes":{"app.kubernetes.io\);\n\1;g' | grep '"che-theia.eclipse.org/vscode-extensions":' | grep -e '^{"attributes".*'); do \
-                dest=$(echo "$container" | sed 's;.*{"name":"THEIA_PLUGINS","value":"local-dir://\([^"][^"]*\)"}.*;\1;' - ) ;\
-                urls=$(echo "$container" | sed 's;.*"che-theia.eclipse.org/vscode-extensions":\[\([^]][^]]*\)\]}.*;\1;' - ) ;\
-                mkdir -p $dest ;\
-                for url in $(echo $urls | sed 's/[",]/ /g' - ); do \
-                  echo; echo downloading $urls to $dest; curl -L $url > $dest/$(basename $url) ;\
-                done \
-              done \
-          image: 'quay.io/samsahai/curl:latest'
-          volumeMounts:
-            - path: "/plugins"
-              name: plugins
-
-      - name: remote-endpoint
-        volume: {}
-          # ephemeral: true                #### We should add it in the Devfile 2.0 spec ! Not critical to implement at start though
-
-      - name: remote-runtime-injector
-        attributes:
-          "app.kubernetes.io/part-of": che-theia.eclipse.org
-          "app.kubernetes.io/component": bootstrapper
-        container:                          #### corresponds to `initContainer` definition in old meta.yaml.
-          image: "quay.io/eclipse/che-theia-endpoint-runtime-binary:7.20.0"
-          volumeMounts:
-            - path: "/remote-endpoint"
-              name: remote-endpoint
-          env:
-            - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
-              value: /remote-endpoint/plugin-remote-endpoint
-            - name: REMOTE_ENDPOINT_VOLUME_NAME
-              value: remote-endpoint
-
-      - name: che-machine-exec
-        attributes:
-          "app.kubernetes.io/name": che-terminal.eclipse.org
+          "app.kubernetes.io/name": che-theia.eclipse.org
           "app.kubernetes.io/part-of": che.eclipse.org
-          "app.kubernetes.io/component": terminal
+          "app.kubernetes.io/component": che-theia-terminal
         container:
-          image: "quay.io/eclipse/che-machine-exec:7.20.0"
+          image: "quay.io/eclipse/che-machine-exec:nightly"
           command: ['/go/bin/che-machine-exec']
           args:
             - '--url'
-            - '0.0.0.0:4444'
+            - '0.0.0.0:3333'
             - '--pod-selector'
-            - controller.devfile.io/workspace_id=$(CHE_WORKSPACE_ID)
+            - controller.devfile.io/workspace_id=$(DEVWORKSPACE_ID)
           endpoints:
-            - name: "che-mach-exec"
+            - name: "che-theia-terminal"
               exposure: public
-              targetPort: 4444
+              targetPort: 3333
               protocol: ws
               secure: true
               attributes:
-                type: terminal
-                cookiesAuthEnabled: "true"
-      - name: vscode-typescript
-        attributes:
-          "app.kubernetes.io/part-of": che-theia.eclipse.org
-          "app.kubernetes.io/component": vscode-plugin
-
-          # Added by Che-theia at start when detecting, after cloning, that the extensions.json in the repo
-          # contains the typescript vscode plugin.
-          "che-theia.eclipse.org/vscode-extensions":
-            - https://download.jboss.org/jbosstools/vscode/3rdparty/ms-code.typescript/che-typescript-language-1.35.1.vsix
-
-        container:
-          image: "quay.io/eclipse/che-sidecar-node:10-0cb5d78"
-          memoryLimit: '512Mi'
-          env:
-            - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
-              value: /remote-endpoint/plugin-remote-endpoint
-            - name: THEIA_PLUGINS
-              value: local-dir:///plugins/sidecars/vscode-typescript
-          volumeMounts:
-            - path: "/remote-endpoint"
-              name: remote-endpoint
-            - name: plugins
-              path: /plugins
-
-      # plugin:
-      #   name: node-debug-plugin
-      #   id: ms-vscode/node-debug2/latest
-
-      - name: vscode-node-debug
-        attributes:
-          "app.kubernetes.io/part-of": che-theia.eclipse.org
-          "app.kubernetes.io/component": vscode-plugin
-
-          # Added by Che-theia at start when detecting, after cloning, that the extensions.json in the repo
-          # contains the typescript vscode plugin.
-          "che-theia.eclipse.org/vscode-extensions":
-            - https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-node-debug/node-debug-1.41.1.vsix
-            - https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-node-debug2/node-debug2-1.42.3.vsix
-
-        container:
-          image: "quay.io/eclipse/che-sidecar-node:12-026416c"
-          memoryLimit: '512Mi'
-          env:
-            - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
-              value: /remote-endpoint/plugin-remote-endpoint
-            - name: THEIA_PLUGINS
-              value: local-dir:///plugins/sidecars/vscode-node-debug
-          volumeMounts:
-            - path: "/remote-endpoint"
-              name: remote-endpoint
-            - path: "/plugins"
-              name: plugins
-
-      # User runtime container
-      - name: nodejs
-        container:
-          image: quay.io/eclipse/che-nodejs10-ubi:nightly
-          memoryLimit: 512Mi
-          endpoints:
-            - name: nodejs
-              protocol: http
-              targetPort: 3000
-          mountSources: true
-
+                type: collocated-terminal
+    ### END Contributions from che-theia plugin ###
     commands:
-
-      # Commands coming from plugin editor
-      - id: inject-theia-in-remote-sidecar
-        apply:
-          component: remote-runtime-injector
-      - id: copy-vsx
-        apply:
-          component: vsx-installer
-
-      # User commands
-      - id: download-dependencies
+      - id: say-hello
         exec:
-          component: nodejs
-          commandLine: npm install
+          component: plugin
+          commandLine: echo "Hello from $(pwd)"
           workingDir: ${PROJECTS_ROOT}/project/app
-      - id: run-the-app
-        exec:
-          component: nodejs
-          commandLine: nodemon app.js
-          workingDir: ${PROJECTS_ROOT}/project/app
-      - id: run-the-app-(debugging-enabled)
-        exec:
-          component: nodejs
-          commandLine: nodemon --inspect app.js
-          workingDir: ${PROJECTS_ROOT}/project/app
-      - id: stop-the-app
-        exec:
-          component: nodejs
-          commandLine: >-
-              node_server_pids=$(pgrep -fx '.*nodemon (--inspect )?app.js' | tr "\\n" " ") &&
-              echo "Stopping node server with PIDs: ${node_server_pids}" &&
-              kill -15 ${node_server_pids} &>/dev/null && echo 'Done.'
-      - id: attach-remote-debugger
-        vscodeLaunch:
-          inlined: |
-            {
-              "version": "0.2.0",
-              "configurations": [
-                {
-                  "type": "node",
-                  "request": "attach",
-                  "name": "Attach to Remote",
-                  "address": "localhost",
-                  "port": 9229,
-                  "localRoot": "${workspaceFolder}",
-                  "remoteRoot": "${workspaceFolder}"
-                }
-              ]
-            }
-
-    events:
-      preStart:
-        - inject-theia-in-remote-sidecar
-        - copy-vsx


### PR DESCRIPTION
Signed-off-by: Flavius Lacatusu <flacatus@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->
### What does this PR do?
Old theia-nodejs theia samples is not working properly since: https://github.com/devfile/api/pull/235. When I apply the old samples I received in terminal:
``` log
The DevWorkspace "theia-nodejs" is invalid: spec.template.commands.id: Invalid value: "run-the-app-(debugging-enabled)": spec.template.commands.id in body should match '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
```
In the current PR I replaced the old theia-nodejs sample with devworkspace example: https://github.com/devfile/devworkspace-operator/blob/main/samples/flattened_theia-next.yaml.
### What issues does this PR fix or reference?
