### PR TITLE
Generate CRDs in v1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,8 @@ compile: generate fmt vet
 
 ### prepare: Prepares the cluster for running the operator - deploys CRDs, rbac and the service account
 prepare: _mk_temp _platform manifests
-# hiding the definition the variable in an eval makes it only defined once this target has run. 
-# Otherwise it would be evaluated eagerly at the make start regardless of the target run, resulting 
+# hiding the definition the variable in an eval makes it only defined once this target has run.
+# Otherwise it would be evaluated eagerly at the make start regardless of the target run, resulting
 # in a temporary directory being created needlessly.
 	$(eval PREPARE_OUTPUT_DIR := $(shell mktemp -p $(TEMP_DIR) -d))
 	OUTPUT_DIR=$(PREPARE_OUTPUT_DIR) DWCO_GENERATED_OVERLAY=support deploy/generate-deployment.sh --split-yaml
@@ -68,7 +68,7 @@ run_as_current_user: generate fmt vet prepare
 
 debug: generate fmt vet prepare
 	dlv debug --listen=:2345 --headless=true --api-version=2 ./main.go --
-	
+
 ### install: Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 install: _platform generate_deployment
 	$(K8S_CLI) create namespace $(DWCO_NAMESPACE) || true
@@ -89,7 +89,7 @@ generate_deployment: manifests
 
 ### manifests: Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen
-	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:artifacts:config=deploy/templates/components/crd crd:crdVersions=v1beta1
+	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:artifacts:config=deploy/templates/components/crd crd:crdVersions=v1
 
 ### fmt: Run go fmt against code
 fmt:

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
   labels:
     app.kubernetes.io/name: devworkspace-che-operator

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -1,8 +1,8 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   labels:
     app.kubernetes.io/name: devworkspace-che-operator
@@ -16,88 +16,88 @@ spec:
     plural: chemanagers
     singular: chemanager
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: CheManager is the configuration of the CheManager layer of Devworkspace.
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: CheManagerSpec holds the configuration of the Che controller.
-          properties:
-            gatewayConfigurerImage:
-              description: GatewayConfigurerImage is the docker image to use for the
-                sidecar of the Che gateway that is used to configure it. This is only
-                used when GatewayDisabled is false. If not defined in the CR, it is
-                taken from the `RELATED_IMAGE_gateway_configurer` environment variable
-                of the che operator deployment/pod. If not defined there, it defaults
-                to a hardcoded value.
-              type: string
-            gatewayDisabled:
-              description: "GatewayDisabled enables or disables routing of the url
-                rewrite supporting devworkspace endpoints through a common gateway
-                (the hostname of which is defined by the GatewayHost). \n Default
-                value is \"false\" meaning that the gateway is enabled. \n If set
-                to false (i.e. the gateway is enabled), endpoints marked using the
-                \"urlRewriteSupported\" attribute are exposed on unique subpaths of
-                the GatewayHost, while the rest of the devworkspace endpoints are
-                exposed on subdomains of the RoutingSuffix specified by the DevWorkspaceRouting
-                of the devworkspace. \n If set to true (i.e. the gateway is disabled),
-                all endpoints are deployed on subdomains of the RoutingSuffix."
-              type: boolean
-            gatewayHost:
-              description: "GatewayHost is the full host name used to expose devworkspace
-                endpoints that support url rewriting reverse proxy. See the GatewayDisabled
-                attribute for a more detailed description of where and how are devworkspace
-                endpoints exposed in various configurations. \n This attribute is
-                mandatory on Kubernetes, optional on OpenShift."
-              type: string
-            gatewayImage:
-              description: GatewayImage is the docker image to use for the Che gateway.  This
-                is only used if GatewayDisabled is false. If not defined in the CR,
-                it is taken from the `RELATED_IMAGE_gateway` environment variable
-                of the che operator deployment/pod. If not defined there, it defaults
-                to a hardcoded value.
-              type: string
-          type: object
-        status:
-          properties:
-            gatewayHost:
-              description: GatewayHost is the resolved host of the ingress/route,
-                on which the gateway is accessible.
-              type: string
-            gatewayPhase:
-              description: GatewayPhase specifies the phase in which the singlehost
-                gateway deployment currently is. If the manager routing is not singlehost,
-                this is "Inactive"
-              type: string
-            message:
-              description: Message contains further human-readable info for why the
-                manager is in the phase it currently is.
-              type: string
-            phase:
-              description: Phase is the phase in which the manager as a whole finds
-                itself in.
-              type: string
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: CheManager is the configuration of the CheManager layer of Devworkspace.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CheManagerSpec holds the configuration of the Che controller.
+            properties:
+              gatewayConfigurerImage:
+                description: GatewayConfigurerImage is the docker image to use for
+                  the sidecar of the Che gateway that is used to configure it. This
+                  is only used when GatewayDisabled is false. If not defined in the
+                  CR, it is taken from the `RELATED_IMAGE_gateway_configurer` environment
+                  variable of the che operator deployment/pod. If not defined there,
+                  it defaults to a hardcoded value.
+                type: string
+              gatewayDisabled:
+                description: "GatewayDisabled enables or disables routing of the url
+                  rewrite supporting devworkspace endpoints through a common gateway
+                  (the hostname of which is defined by the GatewayHost). \n Default
+                  value is \"false\" meaning that the gateway is enabled. \n If set
+                  to false (i.e. the gateway is enabled), endpoints marked using the
+                  \"urlRewriteSupported\" attribute are exposed on unique subpaths
+                  of the GatewayHost, while the rest of the devworkspace endpoints
+                  are exposed on subdomains of the RoutingSuffix specified by the
+                  DevWorkspaceRouting of the devworkspace. \n If set to true (i.e.
+                  the gateway is disabled), all endpoints are deployed on subdomains
+                  of the RoutingSuffix."
+                type: boolean
+              gatewayHost:
+                description: "GatewayHost is the full host name used to expose devworkspace
+                  endpoints that support url rewriting reverse proxy. See the GatewayDisabled
+                  attribute for a more detailed description of where and how are devworkspace
+                  endpoints exposed in various configurations. \n This attribute is
+                  mandatory on Kubernetes, optional on OpenShift."
+                type: string
+              gatewayImage:
+                description: GatewayImage is the docker image to use for the Che gateway.  This
+                  is only used if GatewayDisabled is false. If not defined in the
+                  CR, it is taken from the `RELATED_IMAGE_gateway` environment variable
+                  of the che operator deployment/pod. If not defined there, it defaults
+                  to a hardcoded value.
+                type: string
+            type: object
+          status:
+            properties:
+              gatewayHost:
+                description: GatewayHost is the resolved host of the ingress/route,
+                  on which the gateway is accessible.
+                type: string
+              gatewayPhase:
+                description: GatewayPhase specifies the phase in which the singlehost
+                  gateway deployment currently is. If the manager routing is not singlehost,
+                  this is "Inactive"
+                type: string
+              message:
+                description: Message contains further human-readable info for why
+                  the manager is in the phase it currently is.
+                type: string
+              phase:
+                description: Phase is the phase in which the manager as a whole finds
+                  itself in.
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/deploy/deployment/kubernetes/objects/chemanagers.che.eclipse.org.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/chemanagers.che.eclipse.org.CustomResourceDefinition.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
   labels:
     app.kubernetes.io/name: devworkspace-che-operator

--- a/deploy/deployment/kubernetes/objects/chemanagers.che.eclipse.org.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/chemanagers.che.eclipse.org.CustomResourceDefinition.yaml
@@ -1,8 +1,8 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   labels:
     app.kubernetes.io/name: devworkspace-che-operator
@@ -16,88 +16,88 @@ spec:
     plural: chemanagers
     singular: chemanager
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: CheManager is the configuration of the CheManager layer of Devworkspace.
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: CheManagerSpec holds the configuration of the Che controller.
-          properties:
-            gatewayConfigurerImage:
-              description: GatewayConfigurerImage is the docker image to use for the
-                sidecar of the Che gateway that is used to configure it. This is only
-                used when GatewayDisabled is false. If not defined in the CR, it is
-                taken from the `RELATED_IMAGE_gateway_configurer` environment variable
-                of the che operator deployment/pod. If not defined there, it defaults
-                to a hardcoded value.
-              type: string
-            gatewayDisabled:
-              description: "GatewayDisabled enables or disables routing of the url
-                rewrite supporting devworkspace endpoints through a common gateway
-                (the hostname of which is defined by the GatewayHost). \n Default
-                value is \"false\" meaning that the gateway is enabled. \n If set
-                to false (i.e. the gateway is enabled), endpoints marked using the
-                \"urlRewriteSupported\" attribute are exposed on unique subpaths of
-                the GatewayHost, while the rest of the devworkspace endpoints are
-                exposed on subdomains of the RoutingSuffix specified by the DevWorkspaceRouting
-                of the devworkspace. \n If set to true (i.e. the gateway is disabled),
-                all endpoints are deployed on subdomains of the RoutingSuffix."
-              type: boolean
-            gatewayHost:
-              description: "GatewayHost is the full host name used to expose devworkspace
-                endpoints that support url rewriting reverse proxy. See the GatewayDisabled
-                attribute for a more detailed description of where and how are devworkspace
-                endpoints exposed in various configurations. \n This attribute is
-                mandatory on Kubernetes, optional on OpenShift."
-              type: string
-            gatewayImage:
-              description: GatewayImage is the docker image to use for the Che gateway.  This
-                is only used if GatewayDisabled is false. If not defined in the CR,
-                it is taken from the `RELATED_IMAGE_gateway` environment variable
-                of the che operator deployment/pod. If not defined there, it defaults
-                to a hardcoded value.
-              type: string
-          type: object
-        status:
-          properties:
-            gatewayHost:
-              description: GatewayHost is the resolved host of the ingress/route,
-                on which the gateway is accessible.
-              type: string
-            gatewayPhase:
-              description: GatewayPhase specifies the phase in which the singlehost
-                gateway deployment currently is. If the manager routing is not singlehost,
-                this is "Inactive"
-              type: string
-            message:
-              description: Message contains further human-readable info for why the
-                manager is in the phase it currently is.
-              type: string
-            phase:
-              description: Phase is the phase in which the manager as a whole finds
-                itself in.
-              type: string
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: CheManager is the configuration of the CheManager layer of Devworkspace.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CheManagerSpec holds the configuration of the Che controller.
+            properties:
+              gatewayConfigurerImage:
+                description: GatewayConfigurerImage is the docker image to use for
+                  the sidecar of the Che gateway that is used to configure it. This
+                  is only used when GatewayDisabled is false. If not defined in the
+                  CR, it is taken from the `RELATED_IMAGE_gateway_configurer` environment
+                  variable of the che operator deployment/pod. If not defined there,
+                  it defaults to a hardcoded value.
+                type: string
+              gatewayDisabled:
+                description: "GatewayDisabled enables or disables routing of the url
+                  rewrite supporting devworkspace endpoints through a common gateway
+                  (the hostname of which is defined by the GatewayHost). \n Default
+                  value is \"false\" meaning that the gateway is enabled. \n If set
+                  to false (i.e. the gateway is enabled), endpoints marked using the
+                  \"urlRewriteSupported\" attribute are exposed on unique subpaths
+                  of the GatewayHost, while the rest of the devworkspace endpoints
+                  are exposed on subdomains of the RoutingSuffix specified by the
+                  DevWorkspaceRouting of the devworkspace. \n If set to true (i.e.
+                  the gateway is disabled), all endpoints are deployed on subdomains
+                  of the RoutingSuffix."
+                type: boolean
+              gatewayHost:
+                description: "GatewayHost is the full host name used to expose devworkspace
+                  endpoints that support url rewriting reverse proxy. See the GatewayDisabled
+                  attribute for a more detailed description of where and how are devworkspace
+                  endpoints exposed in various configurations. \n This attribute is
+                  mandatory on Kubernetes, optional on OpenShift."
+                type: string
+              gatewayImage:
+                description: GatewayImage is the docker image to use for the Che gateway.  This
+                  is only used if GatewayDisabled is false. If not defined in the
+                  CR, it is taken from the `RELATED_IMAGE_gateway` environment variable
+                  of the che operator deployment/pod. If not defined there, it defaults
+                  to a hardcoded value.
+                type: string
+            type: object
+          status:
+            properties:
+              gatewayHost:
+                description: GatewayHost is the resolved host of the ingress/route,
+                  on which the gateway is accessible.
+                type: string
+              gatewayPhase:
+                description: GatewayPhase specifies the phase in which the singlehost
+                  gateway deployment currently is. If the manager routing is not singlehost,
+                  this is "Inactive"
+                type: string
+              message:
+                description: Message contains further human-readable info for why
+                  the manager is in the phase it currently is.
+                type: string
+              phase:
+                description: Phase is the phase in which the manager as a whole finds
+                  itself in.
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
   labels:
     app.kubernetes.io/name: devworkspace-che-operator

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -1,8 +1,8 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   labels:
     app.kubernetes.io/name: devworkspace-che-operator
@@ -16,88 +16,88 @@ spec:
     plural: chemanagers
     singular: chemanager
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: CheManager is the configuration of the CheManager layer of Devworkspace.
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: CheManagerSpec holds the configuration of the Che controller.
-          properties:
-            gatewayConfigurerImage:
-              description: GatewayConfigurerImage is the docker image to use for the
-                sidecar of the Che gateway that is used to configure it. This is only
-                used when GatewayDisabled is false. If not defined in the CR, it is
-                taken from the `RELATED_IMAGE_gateway_configurer` environment variable
-                of the che operator deployment/pod. If not defined there, it defaults
-                to a hardcoded value.
-              type: string
-            gatewayDisabled:
-              description: "GatewayDisabled enables or disables routing of the url
-                rewrite supporting devworkspace endpoints through a common gateway
-                (the hostname of which is defined by the GatewayHost). \n Default
-                value is \"false\" meaning that the gateway is enabled. \n If set
-                to false (i.e. the gateway is enabled), endpoints marked using the
-                \"urlRewriteSupported\" attribute are exposed on unique subpaths of
-                the GatewayHost, while the rest of the devworkspace endpoints are
-                exposed on subdomains of the RoutingSuffix specified by the DevWorkspaceRouting
-                of the devworkspace. \n If set to true (i.e. the gateway is disabled),
-                all endpoints are deployed on subdomains of the RoutingSuffix."
-              type: boolean
-            gatewayHost:
-              description: "GatewayHost is the full host name used to expose devworkspace
-                endpoints that support url rewriting reverse proxy. See the GatewayDisabled
-                attribute for a more detailed description of where and how are devworkspace
-                endpoints exposed in various configurations. \n This attribute is
-                mandatory on Kubernetes, optional on OpenShift."
-              type: string
-            gatewayImage:
-              description: GatewayImage is the docker image to use for the Che gateway.  This
-                is only used if GatewayDisabled is false. If not defined in the CR,
-                it is taken from the `RELATED_IMAGE_gateway` environment variable
-                of the che operator deployment/pod. If not defined there, it defaults
-                to a hardcoded value.
-              type: string
-          type: object
-        status:
-          properties:
-            gatewayHost:
-              description: GatewayHost is the resolved host of the ingress/route,
-                on which the gateway is accessible.
-              type: string
-            gatewayPhase:
-              description: GatewayPhase specifies the phase in which the singlehost
-                gateway deployment currently is. If the manager routing is not singlehost,
-                this is "Inactive"
-              type: string
-            message:
-              description: Message contains further human-readable info for why the
-                manager is in the phase it currently is.
-              type: string
-            phase:
-              description: Phase is the phase in which the manager as a whole finds
-                itself in.
-              type: string
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: CheManager is the configuration of the CheManager layer of Devworkspace.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CheManagerSpec holds the configuration of the Che controller.
+            properties:
+              gatewayConfigurerImage:
+                description: GatewayConfigurerImage is the docker image to use for
+                  the sidecar of the Che gateway that is used to configure it. This
+                  is only used when GatewayDisabled is false. If not defined in the
+                  CR, it is taken from the `RELATED_IMAGE_gateway_configurer` environment
+                  variable of the che operator deployment/pod. If not defined there,
+                  it defaults to a hardcoded value.
+                type: string
+              gatewayDisabled:
+                description: "GatewayDisabled enables or disables routing of the url
+                  rewrite supporting devworkspace endpoints through a common gateway
+                  (the hostname of which is defined by the GatewayHost). \n Default
+                  value is \"false\" meaning that the gateway is enabled. \n If set
+                  to false (i.e. the gateway is enabled), endpoints marked using the
+                  \"urlRewriteSupported\" attribute are exposed on unique subpaths
+                  of the GatewayHost, while the rest of the devworkspace endpoints
+                  are exposed on subdomains of the RoutingSuffix specified by the
+                  DevWorkspaceRouting of the devworkspace. \n If set to true (i.e.
+                  the gateway is disabled), all endpoints are deployed on subdomains
+                  of the RoutingSuffix."
+                type: boolean
+              gatewayHost:
+                description: "GatewayHost is the full host name used to expose devworkspace
+                  endpoints that support url rewriting reverse proxy. See the GatewayDisabled
+                  attribute for a more detailed description of where and how are devworkspace
+                  endpoints exposed in various configurations. \n This attribute is
+                  mandatory on Kubernetes, optional on OpenShift."
+                type: string
+              gatewayImage:
+                description: GatewayImage is the docker image to use for the Che gateway.  This
+                  is only used if GatewayDisabled is false. If not defined in the
+                  CR, it is taken from the `RELATED_IMAGE_gateway` environment variable
+                  of the che operator deployment/pod. If not defined there, it defaults
+                  to a hardcoded value.
+                type: string
+            type: object
+          status:
+            properties:
+              gatewayHost:
+                description: GatewayHost is the resolved host of the ingress/route,
+                  on which the gateway is accessible.
+                type: string
+              gatewayPhase:
+                description: GatewayPhase specifies the phase in which the singlehost
+                  gateway deployment currently is. If the manager routing is not singlehost,
+                  this is "Inactive"
+                type: string
+              message:
+                description: Message contains further human-readable info for why
+                  the manager is in the phase it currently is.
+                type: string
+              phase:
+                description: Phase is the phase in which the manager as a whole finds
+                  itself in.
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/deploy/deployment/openshift/objects/chemanagers.che.eclipse.org.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/chemanagers.che.eclipse.org.CustomResourceDefinition.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
   labels:
     app.kubernetes.io/name: devworkspace-che-operator

--- a/deploy/deployment/openshift/objects/chemanagers.che.eclipse.org.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/chemanagers.che.eclipse.org.CustomResourceDefinition.yaml
@@ -1,8 +1,8 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   labels:
     app.kubernetes.io/name: devworkspace-che-operator
@@ -16,88 +16,88 @@ spec:
     plural: chemanagers
     singular: chemanager
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: CheManager is the configuration of the CheManager layer of Devworkspace.
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: CheManagerSpec holds the configuration of the Che controller.
-          properties:
-            gatewayConfigurerImage:
-              description: GatewayConfigurerImage is the docker image to use for the
-                sidecar of the Che gateway that is used to configure it. This is only
-                used when GatewayDisabled is false. If not defined in the CR, it is
-                taken from the `RELATED_IMAGE_gateway_configurer` environment variable
-                of the che operator deployment/pod. If not defined there, it defaults
-                to a hardcoded value.
-              type: string
-            gatewayDisabled:
-              description: "GatewayDisabled enables or disables routing of the url
-                rewrite supporting devworkspace endpoints through a common gateway
-                (the hostname of which is defined by the GatewayHost). \n Default
-                value is \"false\" meaning that the gateway is enabled. \n If set
-                to false (i.e. the gateway is enabled), endpoints marked using the
-                \"urlRewriteSupported\" attribute are exposed on unique subpaths of
-                the GatewayHost, while the rest of the devworkspace endpoints are
-                exposed on subdomains of the RoutingSuffix specified by the DevWorkspaceRouting
-                of the devworkspace. \n If set to true (i.e. the gateway is disabled),
-                all endpoints are deployed on subdomains of the RoutingSuffix."
-              type: boolean
-            gatewayHost:
-              description: "GatewayHost is the full host name used to expose devworkspace
-                endpoints that support url rewriting reverse proxy. See the GatewayDisabled
-                attribute for a more detailed description of where and how are devworkspace
-                endpoints exposed in various configurations. \n This attribute is
-                mandatory on Kubernetes, optional on OpenShift."
-              type: string
-            gatewayImage:
-              description: GatewayImage is the docker image to use for the Che gateway.  This
-                is only used if GatewayDisabled is false. If not defined in the CR,
-                it is taken from the `RELATED_IMAGE_gateway` environment variable
-                of the che operator deployment/pod. If not defined there, it defaults
-                to a hardcoded value.
-              type: string
-          type: object
-        status:
-          properties:
-            gatewayHost:
-              description: GatewayHost is the resolved host of the ingress/route,
-                on which the gateway is accessible.
-              type: string
-            gatewayPhase:
-              description: GatewayPhase specifies the phase in which the singlehost
-                gateway deployment currently is. If the manager routing is not singlehost,
-                this is "Inactive"
-              type: string
-            message:
-              description: Message contains further human-readable info for why the
-                manager is in the phase it currently is.
-              type: string
-            phase:
-              description: Phase is the phase in which the manager as a whole finds
-                itself in.
-              type: string
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: CheManager is the configuration of the CheManager layer of Devworkspace.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CheManagerSpec holds the configuration of the Che controller.
+            properties:
+              gatewayConfigurerImage:
+                description: GatewayConfigurerImage is the docker image to use for
+                  the sidecar of the Che gateway that is used to configure it. This
+                  is only used when GatewayDisabled is false. If not defined in the
+                  CR, it is taken from the `RELATED_IMAGE_gateway_configurer` environment
+                  variable of the che operator deployment/pod. If not defined there,
+                  it defaults to a hardcoded value.
+                type: string
+              gatewayDisabled:
+                description: "GatewayDisabled enables or disables routing of the url
+                  rewrite supporting devworkspace endpoints through a common gateway
+                  (the hostname of which is defined by the GatewayHost). \n Default
+                  value is \"false\" meaning that the gateway is enabled. \n If set
+                  to false (i.e. the gateway is enabled), endpoints marked using the
+                  \"urlRewriteSupported\" attribute are exposed on unique subpaths
+                  of the GatewayHost, while the rest of the devworkspace endpoints
+                  are exposed on subdomains of the RoutingSuffix specified by the
+                  DevWorkspaceRouting of the devworkspace. \n If set to true (i.e.
+                  the gateway is disabled), all endpoints are deployed on subdomains
+                  of the RoutingSuffix."
+                type: boolean
+              gatewayHost:
+                description: "GatewayHost is the full host name used to expose devworkspace
+                  endpoints that support url rewriting reverse proxy. See the GatewayDisabled
+                  attribute for a more detailed description of where and how are devworkspace
+                  endpoints exposed in various configurations. \n This attribute is
+                  mandatory on Kubernetes, optional on OpenShift."
+                type: string
+              gatewayImage:
+                description: GatewayImage is the docker image to use for the Che gateway.  This
+                  is only used if GatewayDisabled is false. If not defined in the
+                  CR, it is taken from the `RELATED_IMAGE_gateway` environment variable
+                  of the che operator deployment/pod. If not defined there, it defaults
+                  to a hardcoded value.
+                type: string
+            type: object
+          status:
+            properties:
+              gatewayHost:
+                description: GatewayHost is the resolved host of the ingress/route,
+                  on which the gateway is accessible.
+                type: string
+              gatewayPhase:
+                description: GatewayPhase specifies the phase in which the singlehost
+                  gateway deployment currently is. If the manager routing is not singlehost,
+                  this is "Inactive"
+                type: string
+              message:
+                description: Message contains further human-readable info for why
+                  the manager is in the phase it currently is.
+                type: string
+              phase:
+                description: Phase is the phase in which the manager as a whole finds
+                  itself in.
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/deploy/templates/components/crd/che.eclipse.org_chemanagers.yaml
+++ b/deploy/templates/components/crd/che.eclipse.org_chemanagers.yaml
@@ -1,10 +1,10 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: chemanagers.che.eclipse.org
 spec:
@@ -15,57 +15,88 @@ spec:
     plural: chemanagers
     singular: chemanager
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: CheManager is the configuration of the CheManager layer of Devworkspace.
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: CheManagerSpec holds the configuration of the Che controller.
-          properties:
-            gatewayConfigurerImage:
-              description: GatewayConfigurerImage is the docker image to use for the sidecar of the Che gateway that is used to configure it. This is only used when GatewayDisabled is false. If not defined in the CR, it is taken from the `RELATED_IMAGE_gateway_configurer` environment variable of the che operator deployment/pod. If not defined there, it defaults to a hardcoded value.
-              type: string
-            gatewayDisabled:
-              description: "GatewayDisabled enables or disables routing of the url rewrite supporting devworkspace endpoints through a common gateway (the hostname of which is defined by the GatewayHost). \n Default value is \"false\" meaning that the gateway is enabled. \n If set to false (i.e. the gateway is enabled), endpoints marked using the \"urlRewriteSupported\" attribute are exposed on unique subpaths of the GatewayHost, while the rest of the devworkspace endpoints are exposed on subdomains of the RoutingSuffix specified by the DevWorkspaceRouting of the devworkspace. \n If set to true (i.e. the gateway is disabled), all endpoints are deployed on subdomains of the RoutingSuffix."
-              type: boolean
-            gatewayHost:
-              description: "GatewayHost is the full host name used to expose devworkspace endpoints that support url rewriting reverse proxy. See the GatewayDisabled attribute for a more detailed description of where and how are devworkspace endpoints exposed in various configurations. \n This attribute is mandatory on Kubernetes, optional on OpenShift."
-              type: string
-            gatewayImage:
-              description: GatewayImage is the docker image to use for the Che gateway.  This is only used if GatewayDisabled is false. If not defined in the CR, it is taken from the `RELATED_IMAGE_gateway` environment variable of the che operator deployment/pod. If not defined there, it defaults to a hardcoded value.
-              type: string
-          type: object
-        status:
-          properties:
-            gatewayHost:
-              description: GatewayHost is the resolved host of the ingress/route, on which the gateway is accessible.
-              type: string
-            gatewayPhase:
-              description: GatewayPhase specifies the phase in which the singlehost gateway deployment currently is. If the manager routing is not singlehost, this is "Inactive"
-              type: string
-            message:
-              description: Message contains further human-readable info for why the manager is in the phase it currently is.
-              type: string
-            phase:
-              description: Phase is the phase in which the manager as a whole finds itself in.
-              type: string
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: CheManager is the configuration of the CheManager layer of Devworkspace.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CheManagerSpec holds the configuration of the Che controller.
+            properties:
+              gatewayConfigurerImage:
+                description: GatewayConfigurerImage is the docker image to use for
+                  the sidecar of the Che gateway that is used to configure it. This
+                  is only used when GatewayDisabled is false. If not defined in the
+                  CR, it is taken from the `RELATED_IMAGE_gateway_configurer` environment
+                  variable of the che operator deployment/pod. If not defined there,
+                  it defaults to a hardcoded value.
+                type: string
+              gatewayDisabled:
+                description: "GatewayDisabled enables or disables routing of the url
+                  rewrite supporting devworkspace endpoints through a common gateway
+                  (the hostname of which is defined by the GatewayHost). \n Default
+                  value is \"false\" meaning that the gateway is enabled. \n If set
+                  to false (i.e. the gateway is enabled), endpoints marked using the
+                  \"urlRewriteSupported\" attribute are exposed on unique subpaths
+                  of the GatewayHost, while the rest of the devworkspace endpoints
+                  are exposed on subdomains of the RoutingSuffix specified by the
+                  DevWorkspaceRouting of the devworkspace. \n If set to true (i.e.
+                  the gateway is disabled), all endpoints are deployed on subdomains
+                  of the RoutingSuffix."
+                type: boolean
+              gatewayHost:
+                description: "GatewayHost is the full host name used to expose devworkspace
+                  endpoints that support url rewriting reverse proxy. See the GatewayDisabled
+                  attribute for a more detailed description of where and how are devworkspace
+                  endpoints exposed in various configurations. \n This attribute is
+                  mandatory on Kubernetes, optional on OpenShift."
+                type: string
+              gatewayImage:
+                description: GatewayImage is the docker image to use for the Che gateway.  This
+                  is only used if GatewayDisabled is false. If not defined in the
+                  CR, it is taken from the `RELATED_IMAGE_gateway` environment variable
+                  of the che operator deployment/pod. If not defined there, it defaults
+                  to a hardcoded value.
+                type: string
+            type: object
+          status:
+            properties:
+              gatewayHost:
+                description: GatewayHost is the resolved host of the ingress/route,
+                  on which the gateway is accessible.
+                type: string
+              gatewayPhase:
+                description: GatewayPhase specifies the phase in which the singlehost
+                  gateway deployment currently is. If the manager routing is not singlehost,
+                  this is "Inactive"
+                type: string
+              message:
+                description: Message contains further human-readable info for why
+                  the manager is in the phase it currently is.
+                type: string
+              phase:
+                description: Phase is the phase in which the manager as a whole finds
+                  itself in.
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/deploy/templates/components/crd/che.eclipse.org_chemanagers.yaml
+++ b/deploy/templates/components/crd/che.eclipse.org_chemanagers.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
   name: chemanagers.che.eclipse.org
 spec:
@@ -22,14 +22,10 @@ spec:
         description: CheManager is the configuration of the CheManager layer of Devworkspace.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -37,59 +33,31 @@ spec:
             description: CheManagerSpec holds the configuration of the Che controller.
             properties:
               gatewayConfigurerImage:
-                description: GatewayConfigurerImage is the docker image to use for
-                  the sidecar of the Che gateway that is used to configure it. This
-                  is only used when GatewayDisabled is false. If not defined in the
-                  CR, it is taken from the `RELATED_IMAGE_gateway_configurer` environment
-                  variable of the che operator deployment/pod. If not defined there,
-                  it defaults to a hardcoded value.
+                description: GatewayConfigurerImage is the docker image to use for the sidecar of the Che gateway that is used to configure it. This is only used when GatewayDisabled is false. If not defined in the CR, it is taken from the `RELATED_IMAGE_gateway_configurer` environment variable of the che operator deployment/pod. If not defined there, it defaults to a hardcoded value.
                 type: string
               gatewayDisabled:
-                description: "GatewayDisabled enables or disables routing of the url
-                  rewrite supporting devworkspace endpoints through a common gateway
-                  (the hostname of which is defined by the GatewayHost). \n Default
-                  value is \"false\" meaning that the gateway is enabled. \n If set
-                  to false (i.e. the gateway is enabled), endpoints marked using the
-                  \"urlRewriteSupported\" attribute are exposed on unique subpaths
-                  of the GatewayHost, while the rest of the devworkspace endpoints
-                  are exposed on subdomains of the RoutingSuffix specified by the
-                  DevWorkspaceRouting of the devworkspace. \n If set to true (i.e.
-                  the gateway is disabled), all endpoints are deployed on subdomains
-                  of the RoutingSuffix."
+                description: "GatewayDisabled enables or disables routing of the url rewrite supporting devworkspace endpoints through a common gateway (the hostname of which is defined by the GatewayHost). \n Default value is \"false\" meaning that the gateway is enabled. \n If set to false (i.e. the gateway is enabled), endpoints marked using the \"urlRewriteSupported\" attribute are exposed on unique subpaths of the GatewayHost, while the rest of the devworkspace endpoints are exposed on subdomains of the RoutingSuffix specified by the DevWorkspaceRouting of the devworkspace. \n If set to true (i.e. the gateway is disabled), all endpoints are deployed on subdomains of the RoutingSuffix."
                 type: boolean
               gatewayHost:
-                description: "GatewayHost is the full host name used to expose devworkspace
-                  endpoints that support url rewriting reverse proxy. See the GatewayDisabled
-                  attribute for a more detailed description of where and how are devworkspace
-                  endpoints exposed in various configurations. \n This attribute is
-                  mandatory on Kubernetes, optional on OpenShift."
+                description: "GatewayHost is the full host name used to expose devworkspace endpoints that support url rewriting reverse proxy. See the GatewayDisabled attribute for a more detailed description of where and how are devworkspace endpoints exposed in various configurations. \n This attribute is mandatory on Kubernetes, optional on OpenShift."
                 type: string
               gatewayImage:
-                description: GatewayImage is the docker image to use for the Che gateway.  This
-                  is only used if GatewayDisabled is false. If not defined in the
-                  CR, it is taken from the `RELATED_IMAGE_gateway` environment variable
-                  of the che operator deployment/pod. If not defined there, it defaults
-                  to a hardcoded value.
+                description: GatewayImage is the docker image to use for the Che gateway.  This is only used if GatewayDisabled is false. If not defined in the CR, it is taken from the `RELATED_IMAGE_gateway` environment variable of the che operator deployment/pod. If not defined there, it defaults to a hardcoded value.
                 type: string
             type: object
           status:
             properties:
               gatewayHost:
-                description: GatewayHost is the resolved host of the ingress/route,
-                  on which the gateway is accessible.
+                description: GatewayHost is the resolved host of the ingress/route, on which the gateway is accessible.
                 type: string
               gatewayPhase:
-                description: GatewayPhase specifies the phase in which the singlehost
-                  gateway deployment currently is. If the manager routing is not singlehost,
-                  this is "Inactive"
+                description: GatewayPhase specifies the phase in which the singlehost gateway deployment currently is. If the manager routing is not singlehost, this is "Inactive"
                 type: string
               message:
-                description: Message contains further human-readable info for why
-                  the manager is in the phase it currently is.
+                description: Message contains further human-readable info for why the manager is in the phase it currently is.
                 type: string
               phase:
-                description: Phase is the phase in which the manager as a whole finds
-                  itself in.
+                description: Phase is the phase in which the manager as a whole finds itself in.
                 type: string
             type: object
         type: object


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
We are going to drop support v1beta1.
This PR generates CRD in v1.
OCP 3.11 will use a dedicated CO deployment file without DWCO specific things.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-1720