### PR TITLE
Upgrade the project to use go 1.14

### DIFF
--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -9,8 +9,8 @@
 #   Red Hat, Inc. - initial API and implementation
 #
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/devtools/go-toolset-rhel7
-FROM registry.access.redhat.com/devtools/go-toolset-rhel7:1.13.15-4  as builder
-ENV PATH=/opt/rh/go-toolset-1.13/root/usr/bin:${PATH} \
+FROM registry.access.redhat.com/devtools/go-toolset-rhel7:1.14.12-4.1615820747 as builder
+ENV PATH=/opt/rh/go-toolset-1.14/root/usr/bin:${PATH} \
     GOPATH=/go/
 
 USER root

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/che-incubator/devworkspace-che-operator
 
-go 1.13
+go 1.14
 
 require (
 	github.com/devfile/api/v2 v2.0.0-20210402145809-1f335562c475


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->
### What does this PR do?
This PR updates the project to use go 1.14. The main reason for this change is for:
```
By default, if the go version in go.mod is 1.14 or higher and a vendor directory is present, the go command acts as if -mod=vendor were used. Otherwise, the go command acts as if -mod=readonly were used.
```
from https://golang.org/ref/mod#build-commands making productization a bit simpler.

Similiar to https://github.com/devfile/devworkspace-operator/pull/427

### What issues does this PR fix or reference?
