### PR TITLE
change traefik image source to prevent pull rate limit problems

### DIFF
--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -518,7 +518,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: RELATED_IMAGE_gateway
-          value: docker.io/traefik:v2.2.8
+          value: quay.io/eclipse/che--traefik:v2.3.2-6e6d4dc5a19afe06778ca092cdbbb98e31cb9f9c313edafa23f81a0e6ddf8a23
         - name: RELATED_IMAGE_gateway_configurer
           value: quay.io/che-incubator/configbump:0.1.4
         image: quay.io/che-incubator/devworkspace-che-operator:ci

--- a/deploy/deployment/kubernetes/objects/devworkspace-che-manager.Deployment.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspace-che-manager.Deployment.yaml
@@ -38,7 +38,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: RELATED_IMAGE_gateway
-          value: docker.io/traefik:v2.2.8
+          value: quay.io/eclipse/che--traefik:v2.3.2-6e6d4dc5a19afe06778ca092cdbbb98e31cb9f9c313edafa23f81a0e6ddf8a23
         - name: RELATED_IMAGE_gateway_configurer
           value: quay.io/che-incubator/configbump:0.1.4
         image: quay.io/che-incubator/devworkspace-che-operator:ci

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -518,7 +518,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: RELATED_IMAGE_gateway
-          value: docker.io/traefik:v2.2.8
+          value: quay.io/eclipse/che--traefik:v2.3.2-6e6d4dc5a19afe06778ca092cdbbb98e31cb9f9c313edafa23f81a0e6ddf8a23
         - name: RELATED_IMAGE_gateway_configurer
           value: quay.io/che-incubator/configbump:0.1.4
         image: quay.io/che-incubator/devworkspace-che-operator:ci

--- a/deploy/deployment/openshift/objects/devworkspace-che-manager.Deployment.yaml
+++ b/deploy/deployment/openshift/objects/devworkspace-che-manager.Deployment.yaml
@@ -38,7 +38,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: RELATED_IMAGE_gateway
-          value: docker.io/traefik:v2.2.8
+          value: quay.io/eclipse/che--traefik:v2.3.2-6e6d4dc5a19afe06778ca092cdbbb98e31cb9f9c313edafa23f81a0e6ddf8a23
         - name: RELATED_IMAGE_gateway_configurer
           value: quay.io/che-incubator/configbump:0.1.4
         image: quay.io/che-incubator/devworkspace-che-operator:ci

--- a/deploy/templates/components/manager/manager.yaml
+++ b/deploy/templates/components/manager/manager.yaml
@@ -40,6 +40,6 @@ spec:
               fieldRef:
                 fieldPath: spec.serviceAccountName
           - name: RELATED_IMAGE_gateway
-            value: "docker.io/traefik:v2.2.8"
+            value: "quay.io/eclipse/che--traefik:v2.3.2-6e6d4dc5a19afe06778ca092cdbbb98e31cb9f9c313edafa23f81a0e6ddf8a23"
           - name: RELATED_IMAGE_gateway_configurer
             value: "quay.io/che-incubator/configbump:0.1.4"

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -12,7 +12,7 @@ const (
 	gatewayImageEnvVarName           = "RELATED_IMAGE_gateway"
 	gatewayConfigurerImageEnvVarName = "RELATED_IMAGE_gateway_configurer"
 
-	defaultGatewayImage           = "docker.io/traefik:v2.2.8"
+	defaultGatewayImage           = "quay.io/eclipse/che--traefik:v2.3.2-6e6d4dc5a19afe06778ca092cdbbb98e31cb9f9c313edafa23f81a0e6ddf8a23"
 	defaultGatewayConfigurerImage = "quay.io/che-incubator/configbump:0.1.4"
 
 	configAnnotationPrefix                       = "che.routing.controller.devfile.io/"


### PR DESCRIPTION
Signed-off-by: xbaran4 <pbaran@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->
### What does this PR do?
Changes treafik docker image source to quay.io to prevent image pull rate limit issue that sometimes prevents devworkspace-che from deploying.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/19814