### PR TITLE
Adapt DWCO to enabling concurrent reconciles on DWO side

### DIFF
--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -513,6 +513,8 @@ spec:
               fieldPath: metadata.name
         - name: OPERATOR_NAME
           value: devworkspace-operator
+        - name: MAX_CONCURRENT_RECONCILES
+          value: "1"
         - name: CONTROLLER_SERVICE_ACCOUNT_NAME
           valueFrom:
             fieldRef:

--- a/deploy/deployment/kubernetes/objects/devworkspace-che-manager.Deployment.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspace-che-manager.Deployment.yaml
@@ -33,6 +33,8 @@ spec:
               fieldPath: metadata.name
         - name: OPERATOR_NAME
           value: devworkspace-operator
+        - name: MAX_CONCURRENT_RECONCILES
+          value: "1"
         - name: CONTROLLER_SERVICE_ACCOUNT_NAME
           valueFrom:
             fieldRef:

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -513,6 +513,8 @@ spec:
               fieldPath: metadata.name
         - name: OPERATOR_NAME
           value: devworkspace-operator
+        - name: MAX_CONCURRENT_RECONCILES
+          value: "1"
         - name: CONTROLLER_SERVICE_ACCOUNT_NAME
           valueFrom:
             fieldRef:

--- a/deploy/deployment/openshift/objects/devworkspace-che-manager.Deployment.yaml
+++ b/deploy/deployment/openshift/objects/devworkspace-che-manager.Deployment.yaml
@@ -33,6 +33,8 @@ spec:
               fieldPath: metadata.name
         - name: OPERATOR_NAME
           value: devworkspace-operator
+        - name: MAX_CONCURRENT_RECONCILES
+          value: "1"
         - name: CONTROLLER_SERVICE_ACCOUNT_NAME
           valueFrom:
             fieldRef:

--- a/deploy/templates/components/manager/manager.yaml
+++ b/deploy/templates/components/manager/manager.yaml
@@ -35,6 +35,8 @@ spec:
                 fieldPath: metadata.name
           - name: OPERATOR_NAME
             value: "devworkspace-operator"
+          - name: MAX_CONCURRENT_RECONCILES
+            value: "1"
           - name: CONTROLLER_SERVICE_ACCOUNT_NAME
             valueFrom:
               fieldRef:


### PR DESCRIPTION
### What does this PR do?
Adapts DWCO to enabling concurrent reconciles on DWO side.

### What issues does this PR fix or reference?
It adapts DWCO for https://github.com/devfile/devworkspace-operator/pull/396

### Is this PR tested?
Yes! Before I had on my RHPDS cluster - imageCrashLoopback, after `make install` from this PR containers is started.