### PR TITLE
Wildcard certificates don't work on sub-sub domains

### DIFF
--- a/apis/che-controller/v1alpha1/component_types.go
+++ b/apis/che-controller/v1alpha1/component_types.go
@@ -26,6 +26,11 @@ type CheManagerSpec struct {
 	// This attribute is mandatory on Kubernetes, optional on OpenShift.
 	GatewayHost string `json:"gatewayHost,omitempty"`
 
+	// The workspace endpoints that need to be deployed on a subdomain will be deployed on subdomains of this base domain.
+	// This is mandatory on Kubernetes. On OpenShift, an attempt is made to automatically figure out the base domain of
+	// the routes. The resolved value of this property is written to the status.
+	WorkspaceBaseDomain string `json:"workspaceBaseDomain,omitempty"`
+
 	// GatewayDisabled enables or disables routing of the url rewrite supporting devworkspace endpoints
 	// through a common gateway (the hostname of which is defined by the GatewayHost).
 	//
@@ -112,6 +117,11 @@ type CheManagerStatus struct {
 
 	// Message contains further human-readable info for why the manager is in the phase it currently is.
 	Message string `json:"message,omitempty"`
+
+	// The resolved workspace base domain. This is either the copy of the explicitly defined property of the
+	// same name in the spec or, if it is undefined in the spec and we're running on OpenShift, the automatically
+	// resolved basedomain for routes.
+	WorkspaceBaseDomain string `json:"workspaceBaseDomain,omitempty"`
 }
 
 // CheManager is the configuration of the CheManager layer of Devworkspace.

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -98,6 +98,13 @@ spec:
                   endpoints, the secret is copied to the namespace of the devworkspace.
                   \n The secret has to be of type \"tls\"."
                 type: string
+              workspaceBaseDomain:
+                description: The workspace endpoints that need to be deployed on a
+                  subdomain will be deployed on subdomains of this base domain. This
+                  is mandatory on Kubernetes. On OpenShift, an attempt is made to
+                  automatically figure out the base domain of the routes. The resolved
+                  value of this property is written to the status.
+                type: string
             type: object
           status:
             properties:
@@ -117,6 +124,12 @@ spec:
               phase:
                 description: Phase is the phase in which the manager as a whole finds
                   itself in.
+                type: string
+              workspaceBaseDomain:
+                description: The resolved workspace base domain. This is either the
+                  copy of the explicitly defined property of the same name in the
+                  spec or, if it is undefined in the spec and we're running on OpenShift,
+                  the automatically resolved basedomain for routes.
                 type: string
             type: object
         type: object

--- a/deploy/deployment/kubernetes/objects/chemanagers.che.eclipse.org.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/chemanagers.che.eclipse.org.CustomResourceDefinition.yaml
@@ -98,6 +98,13 @@ spec:
                   endpoints, the secret is copied to the namespace of the devworkspace.
                   \n The secret has to be of type \"tls\"."
                 type: string
+              workspaceBaseDomain:
+                description: The workspace endpoints that need to be deployed on a
+                  subdomain will be deployed on subdomains of this base domain. This
+                  is mandatory on Kubernetes. On OpenShift, an attempt is made to
+                  automatically figure out the base domain of the routes. The resolved
+                  value of this property is written to the status.
+                type: string
             type: object
           status:
             properties:
@@ -117,6 +124,12 @@ spec:
               phase:
                 description: Phase is the phase in which the manager as a whole finds
                   itself in.
+                type: string
+              workspaceBaseDomain:
+                description: The resolved workspace base domain. This is either the
+                  copy of the explicitly defined property of the same name in the
+                  spec or, if it is undefined in the spec and we're running on OpenShift,
+                  the automatically resolved basedomain for routes.
                 type: string
             type: object
         type: object

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -98,6 +98,13 @@ spec:
                   endpoints, the secret is copied to the namespace of the devworkspace.
                   \n The secret has to be of type \"tls\"."
                 type: string
+              workspaceBaseDomain:
+                description: The workspace endpoints that need to be deployed on a
+                  subdomain will be deployed on subdomains of this base domain. This
+                  is mandatory on Kubernetes. On OpenShift, an attempt is made to
+                  automatically figure out the base domain of the routes. The resolved
+                  value of this property is written to the status.
+                type: string
             type: object
           status:
             properties:
@@ -117,6 +124,12 @@ spec:
               phase:
                 description: Phase is the phase in which the manager as a whole finds
                   itself in.
+                type: string
+              workspaceBaseDomain:
+                description: The resolved workspace base domain. This is either the
+                  copy of the explicitly defined property of the same name in the
+                  spec or, if it is undefined in the spec and we're running on OpenShift,
+                  the automatically resolved basedomain for routes.
                 type: string
             type: object
         type: object

--- a/deploy/deployment/openshift/objects/chemanagers.che.eclipse.org.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/chemanagers.che.eclipse.org.CustomResourceDefinition.yaml
@@ -98,6 +98,13 @@ spec:
                   endpoints, the secret is copied to the namespace of the devworkspace.
                   \n The secret has to be of type \"tls\"."
                 type: string
+              workspaceBaseDomain:
+                description: The workspace endpoints that need to be deployed on a
+                  subdomain will be deployed on subdomains of this base domain. This
+                  is mandatory on Kubernetes. On OpenShift, an attempt is made to
+                  automatically figure out the base domain of the routes. The resolved
+                  value of this property is written to the status.
+                type: string
             type: object
           status:
             properties:
@@ -117,6 +124,12 @@ spec:
               phase:
                 description: Phase is the phase in which the manager as a whole finds
                   itself in.
+                type: string
+              workspaceBaseDomain:
+                description: The resolved workspace base domain. This is either the
+                  copy of the explicitly defined property of the same name in the
+                  spec or, if it is undefined in the spec and we're running on OpenShift,
+                  the automatically resolved basedomain for routes.
                 type: string
             type: object
         type: object

--- a/deploy/templates/components/crd/che.eclipse.org_chemanagers.yaml
+++ b/deploy/templates/components/crd/che.eclipse.org_chemanagers.yaml
@@ -56,6 +56,9 @@ spec:
               tlsSecretName:
                 description: "Name of a secret that will be used to setup ingress/route TLS certificate. When the field is empty string, the default cluster certificate will be used. The same secret is assumed to exist in the same namespace as the CheManager CR and is used for both the gateway and all devworkspace endpoints. In case of the devworkspace endpoints, the secret is copied to the namespace of the devworkspace. \n The secret has to be of type \"tls\"."
                 type: string
+              workspaceBaseDomain:
+                description: The workspace endpoints that need to be deployed on a subdomain will be deployed on subdomains of this base domain. This is mandatory on Kubernetes. On OpenShift, an attempt is made to automatically figure out the base domain of the routes. The resolved value of this property is written to the status.
+                type: string
             type: object
           status:
             properties:
@@ -70,6 +73,9 @@ spec:
                 type: string
               phase:
                 description: Phase is the phase in which the manager as a whole finds itself in.
+                type: string
+              workspaceBaseDomain:
+                description: The resolved workspace base domain. This is either the copy of the explicitly defined property of the same name in the spec or, if it is undefined in the spec and we're running on OpenShift, the automatically resolved basedomain for routes.
                 type: string
             type: object
         type: object

--- a/pkg/manager/chemanager_controller_test.go
+++ b/pkg/manager/chemanager_controller_test.go
@@ -51,7 +51,8 @@ func TestCreatesObjectsInSingleHost(t *testing.T) {
 			Namespace: ns,
 		},
 		Spec: v1alpha1.CheManagerSpec{
-			GatewayHost: "over.the.rainbow",
+			GatewayHost:         "over.the.rainbow",
+			WorkspaceBaseDomain: "down.on.earth",
 		},
 	})
 
@@ -124,7 +125,8 @@ func TestUpdatesObjectsInSingleHost(t *testing.T) {
 				Finalizers: []string{FinalizerName},
 			},
 			Spec: v1alpha1.CheManagerSpec{
-				GatewayHost: "over.the.rainbow",
+				GatewayHost:         "over.the.rainbow",
+				WorkspaceBaseDomain: "down.on.earth",
 			},
 		})
 
@@ -165,8 +167,9 @@ func TestDoesntCreateObjectsInMultiHost(t *testing.T) {
 			Finalizers: []string{FinalizerName},
 		},
 		Spec: v1alpha1.CheManagerSpec{
-			GatewayHost:     "over.the.rainbow",
-			GatewayDisabled: true,
+			GatewayHost:         "over.the.rainbow",
+			WorkspaceBaseDomain: "down.on.earth",
+			GatewayDisabled:     true,
 		},
 	})
 
@@ -230,8 +233,9 @@ func TestDeletesObjectsInMultiHost(t *testing.T) {
 				Finalizers: []string{FinalizerName},
 			},
 			Spec: v1alpha1.CheManagerSpec{
-				GatewayHost:     "over.the.rainbow",
-				GatewayDisabled: true,
+				GatewayHost:         "over.the.rainbow",
+				WorkspaceBaseDomain: "down.on.earth",
+				GatewayDisabled:     true,
 			},
 		})
 
@@ -281,8 +285,9 @@ func TestNoManagerSharedWhenReconcilingNonExistent(t *testing.T) {
 			Finalizers: []string{FinalizerName},
 		},
 		Spec: v1alpha1.CheManagerSpec{
-			GatewayHost:     "over.the.rainbow",
-			GatewayDisabled: true,
+			GatewayHost:         "over.the.rainbow",
+			WorkspaceBaseDomain: "down.on.earth",
+			GatewayDisabled:     true,
 		},
 	})
 
@@ -313,8 +318,9 @@ func TestAddsManagerToSharedMapOnCreate(t *testing.T) {
 			Finalizers: []string{FinalizerName},
 		},
 		Spec: v1alpha1.CheManagerSpec{
-			GatewayHost:     "over.the.rainbow",
-			GatewayDisabled: true,
+			GatewayHost:         "over.the.rainbow",
+			WorkspaceBaseDomain: "down.on.earth",
+			GatewayDisabled:     true,
 		},
 	})
 
@@ -357,8 +363,9 @@ func TestUpdatesManagerInSharedMapOnUpdate(t *testing.T) {
 			Finalizers: []string{FinalizerName},
 		},
 		Spec: v1alpha1.CheManagerSpec{
-			GatewayHost:     "over.the.rainbow",
-			GatewayDisabled: true,
+			GatewayHost:         "over.the.rainbow",
+			WorkspaceBaseDomain: "down.on.earth",
+			GatewayDisabled:     true,
 		},
 	})
 
@@ -449,8 +456,9 @@ func TestRemovesManagerFromSharedMapOnDelete(t *testing.T) {
 			Finalizers: []string{FinalizerName},
 		},
 		Spec: v1alpha1.CheManagerSpec{
-			GatewayHost:     "over.the.rainbow",
-			GatewayDisabled: true,
+			GatewayHost:         "over.the.rainbow",
+			WorkspaceBaseDomain: "down.on.earth",
+			GatewayDisabled:     true,
 		},
 	})
 
@@ -504,7 +512,8 @@ func TestManagerFinalization(t *testing.T) {
 				Finalizers: []string{FinalizerName},
 			},
 			Spec: v1alpha1.CheManagerSpec{
-				GatewayHost: "over.the.rainbow",
+				GatewayHost:         "over.the.rainbow",
+				WorkspaceBaseDomain: "down.on.earth",
 			},
 		},
 		&corev1.ConfigMap{

--- a/pkg/solver/che_routing_test.go
+++ b/pkg/solver/che_routing_test.go
@@ -91,7 +91,8 @@ func getSpecObjects(t *testing.T, routing *dwo.DevWorkspaceRouting) (client.Clie
 			Finalizers: []string{manager.FinalizerName},
 		},
 		Spec: v1alpha1.CheManagerSpec{
-			GatewayHost: "over.the.rainbow",
+			GatewayHost:         "over.the.rainbow",
+			WorkspaceBaseDomain: "down.on.earth",
 		},
 	}, routing)
 }
@@ -319,7 +320,7 @@ func TestCreateSubDomainObjects(t *testing.T) {
 		if len(objs.Ingresses) != 1 {
 			t.Error()
 		}
-		if objs.Ingresses[0].Spec.Rules[0].Host != "wsid-1.over.the.rainbow" {
+		if objs.Ingresses[0].Spec.Rules[0].Host != "wsid-1.down.on.earth" {
 			t.Error()
 		}
 	})
@@ -329,7 +330,7 @@ func TestCreateSubDomainObjects(t *testing.T) {
 		if len(objs.Routes) != 1 {
 			t.Error()
 		}
-		if objs.Routes[0].Spec.Host != "wsid-1.over.the.rainbow" {
+		if objs.Routes[0].Spec.Host != "wsid-1.down.on.earth" {
 			t.Error()
 		}
 	})
@@ -418,24 +419,24 @@ func TestReportSubdomainExposedEndpoints(t *testing.T) {
 	if e1.Name != "e1" {
 		t.Errorf("The first endpoint should have been e1 but is %s", e1.Name)
 	}
-	if e1.Url != "https://wsid-1.over.the.rainbow/1/" {
-		t.Errorf("The e1 endpoint should have the following URL: '%s' but has '%s'.", "https://wsid-1.over.the.rainbow/1/", e1.Url)
+	if e1.Url != "https://wsid-1.down.on.earth/1/" {
+		t.Errorf("The e1 endpoint should have the following URL: '%s' but has '%s'.", "https://wsid-1.down.on.earth/1/", e1.Url)
 	}
 
 	e2 := m1[1]
 	if e2.Name != "e2" {
 		t.Errorf("The second endpoint should have been e2 but is %s", e1.Name)
 	}
-	if e2.Url != "https://wsid-1.over.the.rainbow/2.js" {
-		t.Errorf("The e2 endpoint should have the following URL: '%s' but has '%s'.", "https://wsid-1.over.the.rainbow/2.js", e2.Url)
+	if e2.Url != "https://wsid-1.down.on.earth/2.js" {
+		t.Errorf("The e2 endpoint should have the following URL: '%s' but has '%s'.", "https://wsid-1.down.on.earth/2.js", e2.Url)
 	}
 
 	e3 := m1[2]
 	if e3.Name != "e3" {
 		t.Errorf("The third endpoint should have been e3 but is %s", e1.Name)
 	}
-	if e3.Url != "http://wsid-1.over.the.rainbow/" {
-		t.Errorf("The e3 endpoint should have the following URL: '%s' but has '%s'.", "https://wsid-1.over.the.rainbow/", e3.Url)
+	if e3.Url != "http://wsid-1.down.on.earth/" {
+		t.Errorf("The e3 endpoint should have the following URL: '%s' but has '%s'.", "https://wsid-1.down.on.earth/", e3.Url)
 	}
 }
 
@@ -498,7 +499,8 @@ func TestUsesIngressAnnotationsForWorkspaceEndpointIngresses(t *testing.T) {
 			Finalizers: []string{manager.FinalizerName},
 		},
 		Spec: v1alpha1.CheManagerSpec{
-			GatewayHost: "over.the.rainbow",
+			GatewayHost:         "over.the.rainbow",
+			WorkspaceBaseDomain: "down.on.earth",
 			K8s: v1alpha1.CheManagerSpecK8s{
 				IngressAnnotations: map[string]string{
 					"a": "b",
@@ -534,8 +536,9 @@ func TestUsesCustomCertificateForWorkspaceEndpointIngresses(t *testing.T) {
 			Finalizers: []string{manager.FinalizerName},
 		},
 		Spec: v1alpha1.CheManagerSpec{
-			GatewayHost:   "beyond.comprehension",
-			TlsSecretName: "tlsSecret",
+			GatewayHost:         "beyond.comprehension",
+			WorkspaceBaseDomain: "almost.trivial",
+			TlsSecretName:       "tlsSecret",
 		},
 	}
 
@@ -568,7 +571,7 @@ func TestUsesCustomCertificateForWorkspaceEndpointIngresses(t *testing.T) {
 		t.Fatalf("Unexpected number of host records on the TLS spec: %d", len(ingress.Spec.TLS[0].Hosts))
 	}
 
-	if ingress.Spec.TLS[0].Hosts[0] != "wsid-1.beyond.comprehension" {
+	if ingress.Spec.TLS[0].Hosts[0] != "wsid-1.almost.trivial" {
 		t.Errorf("Unexpected host name of the TLS spec: %s", ingress.Spec.TLS[0].Hosts[0])
 	}
 }
@@ -583,8 +586,9 @@ func TestUsesCustomCertificateForWorkspaceEndpointRoutes(t *testing.T) {
 			Finalizers: []string{manager.FinalizerName},
 		},
 		Spec: v1alpha1.CheManagerSpec{
-			GatewayHost:   "beyond.comprehension",
-			TlsSecretName: "tlsSecret",
+			GatewayHost:         "beyond.comprehension",
+			WorkspaceBaseDomain: "almost.trivial",
+			TlsSecretName:       "tlsSecret",
 		},
 	}
 

--- a/pkg/solver/endpoint_exposer.go
+++ b/pkg/solver/endpoint_exposer.go
@@ -62,7 +62,7 @@ func getEndpointExposingObjectName(componentName string, workspaceID string, por
 }
 
 func (e *RouteExposer) initFrom(ctx context.Context, cl client.Client, manager *v1alpha1.CheManager, routing *dwo.DevWorkspaceRouting) error {
-	e.baseDomain = manager.Status.GatewayHost
+	e.baseDomain = manager.Status.WorkspaceBaseDomain
 	e.devWorkspaceID = routing.Spec.DevWorkspaceId
 
 	if manager.Spec.TlsSecretName != "" {
@@ -80,7 +80,7 @@ func (e *RouteExposer) initFrom(ctx context.Context, cl client.Client, manager *
 }
 
 func (e *IngressExposer) initFrom(ctx context.Context, cl client.Client, manager *v1alpha1.CheManager, routing *dwo.DevWorkspaceRouting, ingressAnnotations map[string]string) error {
-	e.baseDomain = manager.Status.GatewayHost
+	e.baseDomain = manager.Status.WorkspaceBaseDomain
 	e.devWorkspaceID = routing.Spec.DevWorkspaceId
 	e.ingressAnnotations = ingressAnnotations
 


### PR DESCRIPTION
### What does this PR do?
This improves the fix for eclipse/che#19631 introduced in https://github.com/che-incubator/devworkspace-che-operator/pull/45 by
introducing a new config property similar to the `RoutingSuffix`. As it turns out, a wildcard certificate `*.a.b.c` is not valid for `sub.sub.a.b.c`, only for `sub.a.b.c`.

### What issues does this PR fix or reference?
eclipse/che#19631
