### PR TITLE
Add next tag to a ci image build job

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -26,7 +26,7 @@ jobs:
       id: tags
       run: |
         IMG=quay.io/che-incubator/devworkspace-che-operator
-        TAGS="${IMG}:ci,${IMG}:sha-${GITHUB_SHA::8}"
+        TAGS="${IMG}:next,${IMG}:ci,${IMG}:sha-${GITHUB_SHA::8}"
         echo ::set-output name=tags::${TAGS}
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1


### PR DESCRIPTION
Signed-off-by: Mykhailo Kuznietsov <mkuznets@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->
### What does this PR do?
Add "next" tag, with intent to replace "ci" tag, to make it aligned with other Che projects.
"ci" tag will be removed later in separate PR

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/19291